### PR TITLE
Handle MySQL compatibility for rental agreement migration

### DIFF
--- a/database/migrations/2025_10_02_181649_create_rental_agreements_table.php
+++ b/database/migrations/2025_10_02_181649_create_rental_agreements_table.php
@@ -9,9 +9,9 @@ return new class extends Migration
     /**
      * Run the migrations.
      */
-	public function up(): void
-	{
-		Schema::create('rental_agreements', function (Blueprint $table) {
+        public function up(): void
+        {
+                Schema::create('rental_agreements', function (Blueprint $table) {
 			$table->id();
 			$table->foreignId('vehicle_id')->constrained()->cascadeOnDelete();
 			$table->foreignId('customer_id')->constrained()->cascadeOnDelete();
@@ -39,11 +39,18 @@ return new class extends Migration
 
 			$table->timestamps();
 
-			// Un singur contract activ per vehicul
-			$table->unique(['vehicle_id','status'], 'vehicle_active_unique')
-				  ->where('status', 'active');
-		});
-	}
+                        // Un singur contract activ per vehicul
+                        if (Schema::getConnection()->getDriverName() === 'mysql') {
+                                $table->unsignedBigInteger('active_vehicle_id')
+                                      ->virtualAs("case when `status` = 'active' then `vehicle_id` else null end");
+
+                                $table->unique('active_vehicle_id', 'vehicle_active_unique');
+                        } else {
+                                $table->unique(['vehicle_id','status'], 'vehicle_active_unique')
+                                      ->where('status', 'active');
+                        }
+                });
+        }
 
     /**
      * Reverse the migrations.


### PR DESCRIPTION
## Summary
- ensure the rental agreements migration uses a generated column and unique index when running on MySQL
- retain the partial unique index for other database drivers

## Testing
- php artisan migrate:fresh --force

------
https://chatgpt.com/codex/tasks/task_e_68e01b19f23c832c8ff942e0f04a373e