### PR TITLE
Add REST API scaffolding for fleet MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ yarn-error.log
 /.vscode
 /.DS_Store
 /public/build
+
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# AME RENTALS – Laravel App
+# AME Rentals Platform
+
+## Getting Started
+
+1. Install PHP dependencies:
+
+   ```bash
+   composer install
+   ```
+
+2. Create your environment file and generate an application key:
+
+   ```bash
+   cp .env.example .env # create your own if the example file is not available
+   php artisan key:generate
+   ```
+
+3. For local development this project uses SQLite by default. Ensure the database file exists:
+
+   ```bash
+   touch database/database.sqlite
+   ```
+
+4. Run the database migrations:
+
+   ```bash
+   php artisan migrate
+   ```
+
+5. (Optional) Install the JavaScript dependencies for the Filament admin panel assets:
+
+   ```bash
+   npm install
+   npm run build
+   ```
+
+## API Overview
+
+The first iteration of the fleet rental platform exposes a versioned REST API located under `/api/v1`.
+
+| Resource            | Endpoints                                                                 |
+|---------------------|---------------------------------------------------------------------------|
+| Vehicles            | `GET/POST /api/v1/vehicles`, `GET/PATCH/DELETE /api/v1/vehicles/{id}`     |
+| Customers           | `GET/POST /api/v1/customers`, `GET/PATCH/DELETE /api/v1/customers/{id}`   |
+| Rental Agreements   | `GET/POST /api/v1/rental-agreements`, `GET/PATCH/DELETE /api/v1/rental-agreements/{id}` |
+
+### Validation highlights
+
+- Vehicle registration numbers are normalised to uppercase and must be unique.
+- Customers support multiple organisation types (`individual`, `sole_trader`, `partnership`, `ltd`, `llp`).
+- Rental agreements enforce compatible options for billing cycles, mileage policies, and payment cadence.
+
+Each endpoint returns a JSON:API-like payload with the resource stored under the `data` key. Pagination metadata is included automatically when listing resources.
+
+## Testing
+
+Run the feature and unit test suite with:
+
+```bash
+php artisan test
+```
+
+These tests cover the core CRUD flows for vehicles, customers, and rental agreements that underpin Phase 1 of the roadmap.

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case ADMIN = 'admin';
+    case CLIENT = 'client';
+    case DRIVER = 'driver';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/Api/CustomerController.php
+++ b/app/Http/Controllers/Api/CustomerController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\CustomerStoreRequest;
+use App\Http\Requests\CustomerUpdateRequest;
+use App\Http\Resources\CustomerResource;
+use App\Models\Customer;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomerController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $customers = Customer::query()
+            ->orderBy('company_name')
+            ->orderBy('last_name')
+            ->paginate(perPage: request('per_page', 15));
+
+        return CustomerResource::collection($customers);
+    }
+
+    public function store(CustomerStoreRequest $request): JsonResponse
+    {
+        $customer = Customer::create($request->validated());
+
+        return CustomerResource::make($customer)
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(Customer $customer): CustomerResource
+    {
+        return CustomerResource::make($customer);
+    }
+
+    public function update(CustomerUpdateRequest $request, Customer $customer): CustomerResource
+    {
+        $customer->fill($request->validated());
+        $customer->save();
+
+        return CustomerResource::make($customer);
+    }
+
+    public function destroy(Customer $customer): JsonResponse
+    {
+        $customer->delete();
+
+        return response()->json(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/Api/RentalAgreementController.php
+++ b/app/Http/Controllers/Api/RentalAgreementController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\RentalAgreementStoreRequest;
+use App\Http\Requests\RentalAgreementUpdateRequest;
+use App\Http\Resources\RentalAgreementResource;
+use App\Models\RentalAgreement;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+class RentalAgreementController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $agreements = RentalAgreement::query()
+            ->with(['vehicle', 'customer'])
+            ->latest('start_date')
+            ->paginate(perPage: request('per_page', 15));
+
+        return RentalAgreementResource::collection($agreements);
+    }
+
+    public function store(RentalAgreementStoreRequest $request): JsonResponse
+    {
+        $agreement = RentalAgreement::create($request->validated());
+
+        return RentalAgreementResource::make($agreement->load(['vehicle', 'customer']))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(RentalAgreement $rentalAgreement): RentalAgreementResource
+    {
+        return RentalAgreementResource::make($rentalAgreement->load(['vehicle', 'customer']));
+    }
+
+    public function update(RentalAgreementUpdateRequest $request, RentalAgreement $rentalAgreement): RentalAgreementResource
+    {
+        $rentalAgreement->fill($request->validated());
+        $rentalAgreement->save();
+
+        return RentalAgreementResource::make($rentalAgreement->load(['vehicle', 'customer']));
+    }
+
+    public function destroy(RentalAgreement $rentalAgreement): JsonResponse
+    {
+        $rentalAgreement->delete();
+
+        return response()->json(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/Api/VehicleController.php
+++ b/app/Http/Controllers/Api/VehicleController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\VehicleStoreRequest;
+use App\Http\Requests\VehicleUpdateRequest;
+use App\Http\Resources\VehicleResource;
+use App\Models\Vehicle;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+class VehicleController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $vehicles = Vehicle::query()
+            ->orderBy('registration')
+            ->paginate(perPage: request('per_page', 15));
+
+        return VehicleResource::collection($vehicles);
+    }
+
+    public function store(VehicleStoreRequest $request): JsonResponse
+    {
+        $vehicle = Vehicle::create($request->validated());
+
+        return VehicleResource::make($vehicle)
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(Vehicle $vehicle): VehicleResource
+    {
+        return VehicleResource::make($vehicle);
+    }
+
+    public function update(VehicleUpdateRequest $request, Vehicle $vehicle): VehicleResource
+    {
+        $vehicle->fill($request->validated());
+        $vehicle->save();
+
+        return VehicleResource::make($vehicle);
+    }
+
+    public function destroy(Vehicle $vehicle): JsonResponse
+    {
+        $vehicle->delete();
+
+        return response()->json(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,14 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests;
+    use DispatchesJobs;
+    use ValidatesRequests;
 }

--- a/app/Http/Requests/CustomerStoreRequest.php
+++ b/app/Http/Requests/CustomerStoreRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Customer;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CustomerStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('type')) {
+            $this->merge([
+                'type' => strtolower((string) $this->input('type')),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', 'string', Rule::in(Customer::TYPES)],
+            'first_name' => ['nullable', 'string', 'max:100'],
+            'last_name' => ['nullable', 'string', 'max:100'],
+            'company_name' => ['nullable', 'string', 'max:150'],
+            'email' => ['required', 'email', 'max:150', 'unique:customers,email'],
+            'phone' => ['nullable', 'string', 'max:50'],
+            'address_line1' => ['nullable', 'string', 'max:150'],
+            'address_line2' => ['nullable', 'string', 'max:150'],
+            'city' => ['nullable', 'string', 'max:100'],
+            'postcode' => ['nullable', 'string', 'max:20'],
+            'country' => ['nullable', 'string', 'max:100'],
+            'driving_license_no' => ['nullable', 'string', 'max:50'],
+            'dob' => ['nullable', 'date'],
+            'nin' => ['nullable', 'string', 'max:20'],
+        ];
+    }
+}

--- a/app/Http/Requests/CustomerUpdateRequest.php
+++ b/app/Http/Requests/CustomerUpdateRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Customer;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CustomerUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('type')) {
+            $this->merge([
+                'type' => strtolower((string) $this->input('type')),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $customerId = $this->route('customer')->id ?? null;
+
+        return [
+            'type' => ['sometimes', 'string', Rule::in(Customer::TYPES)],
+            'first_name' => ['sometimes', 'nullable', 'string', 'max:100'],
+            'last_name' => ['sometimes', 'nullable', 'string', 'max:100'],
+            'company_name' => ['sometimes', 'nullable', 'string', 'max:150'],
+            'email' => ['sometimes', 'email', 'max:150', Rule::unique('customers', 'email')->ignore($customerId)],
+            'phone' => ['sometimes', 'nullable', 'string', 'max:50'],
+            'address_line1' => ['sometimes', 'nullable', 'string', 'max:150'],
+            'address_line2' => ['sometimes', 'nullable', 'string', 'max:150'],
+            'city' => ['sometimes', 'nullable', 'string', 'max:100'],
+            'postcode' => ['sometimes', 'nullable', 'string', 'max:20'],
+            'country' => ['sometimes', 'nullable', 'string', 'max:100'],
+            'driving_license_no' => ['sometimes', 'nullable', 'string', 'max:50'],
+            'dob' => ['sometimes', 'nullable', 'date'],
+            'nin' => ['sometimes', 'nullable', 'string', 'max:20'],
+        ];
+    }
+}

--- a/app/Http/Requests/RentalAgreementStoreRequest.php
+++ b/app/Http/Requests/RentalAgreementStoreRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\RentalAgreement;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class RentalAgreementStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $fieldsToLower = ['billing_cycle', 'insurance_option', 'mileage_policy', 'payment_day', 'status'];
+
+        foreach ($fieldsToLower as $field) {
+            if ($this->has($field)) {
+                $this->merge([
+                    $field => strtolower((string) $this->input($field)),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'vehicle_id' => ['required', 'exists:vehicles,id'],
+            'customer_id' => ['required', 'exists:customers,id'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+            'billing_cycle' => ['required', 'string', Rule::in(RentalAgreement::BILLING_CYCLES)],
+            'rate_amount' => ['required', 'numeric', 'min:0'],
+            'deposit_amount' => ['required', 'numeric', 'min:0'],
+            'notice_days' => ['required', 'integer', 'between:0,365'],
+            'deposit_release_days' => ['required', 'integer', 'between:0,365'],
+            'insurance_option' => ['required', 'string', Rule::in(RentalAgreement::INSURANCE_OPTIONS)],
+            'mileage_policy' => ['required', 'string', Rule::in(RentalAgreement::MILEAGE_POLICIES)],
+            'mileage_cap' => Rule::when(
+                fn () => $this->input('mileage_policy') === 'cap',
+                ['required', 'integer', 'min:0'],
+                ['nullable', 'integer', 'min:0']
+            ),
+            'cleaning_fee' => ['required', 'numeric', 'min:0'],
+            'admin_fee' => ['required', 'numeric', 'min:0'],
+            'no_smoking' => ['required', 'boolean'],
+            'tracking_enabled' => ['required', 'boolean'],
+            'payment_day' => ['required', 'string', Rule::in(RentalAgreement::PAYMENT_DAYS)],
+            'status' => ['required', 'string', Rule::in(RentalAgreement::STATUSES)],
+        ];
+    }
+}

--- a/app/Http/Requests/RentalAgreementUpdateRequest.php
+++ b/app/Http/Requests/RentalAgreementUpdateRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\RentalAgreement;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class RentalAgreementUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $fieldsToLower = ['billing_cycle', 'insurance_option', 'mileage_policy', 'payment_day', 'status'];
+
+        foreach ($fieldsToLower as $field) {
+            if ($this->has($field)) {
+                $this->merge([
+                    $field => strtolower((string) $this->input($field)),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'vehicle_id' => ['sometimes', 'exists:vehicles,id'],
+            'customer_id' => ['sometimes', 'exists:customers,id'],
+            'start_date' => ['sometimes', 'date'],
+            'end_date' => ['sometimes', 'nullable', 'date', 'after_or_equal:start_date'],
+            'billing_cycle' => ['sometimes', 'string', Rule::in(RentalAgreement::BILLING_CYCLES)],
+            'rate_amount' => ['sometimes', 'numeric', 'min:0'],
+            'deposit_amount' => ['sometimes', 'numeric', 'min:0'],
+            'notice_days' => ['sometimes', 'integer', 'between:0,365'],
+            'deposit_release_days' => ['sometimes', 'integer', 'between:0,365'],
+            'insurance_option' => ['sometimes', 'string', Rule::in(RentalAgreement::INSURANCE_OPTIONS)],
+            'mileage_policy' => ['sometimes', 'string', Rule::in(RentalAgreement::MILEAGE_POLICIES)],
+            'mileage_cap' => Rule::when(
+                fn () => $this->input('mileage_policy') === 'cap',
+                ['required', 'integer', 'min:0'],
+                ['nullable', 'integer', 'min:0']
+            ),
+            'cleaning_fee' => ['sometimes', 'numeric', 'min:0'],
+            'admin_fee' => ['sometimes', 'numeric', 'min:0'],
+            'no_smoking' => ['sometimes', 'boolean'],
+            'tracking_enabled' => ['sometimes', 'boolean'],
+            'payment_day' => ['sometimes', 'string', Rule::in(RentalAgreement::PAYMENT_DAYS)],
+            'status' => ['sometimes', 'string', Rule::in(RentalAgreement::STATUSES)],
+        ];
+    }
+}

--- a/app/Http/Requests/VehicleStoreRequest.php
+++ b/app/Http/Requests/VehicleStoreRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Vehicle;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class VehicleStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('registration')) {
+            $this->merge([
+                'registration' => strtoupper((string) $this->input('registration')),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'registration' => ['required', 'string', 'max:15', 'regex:/^[A-Z0-9]+$/', 'unique:vehicles,registration'],
+            'make' => ['nullable', 'string', 'max:60'],
+            'model' => ['nullable', 'string', 'max:60'],
+            'variant' => ['nullable', 'string', 'max:60'],
+            'year' => ['nullable', 'integer', 'between:1900,' . (date('Y') + 1)],
+            'mileage' => ['nullable', 'integer', 'min:0'],
+            'mot_expiry' => ['nullable', 'date'],
+            'road_tax_due' => ['nullable', 'date'],
+            'purchase_price' => ['nullable', 'numeric', 'min:0'],
+            'monthly_finance' => ['nullable', 'numeric', 'min:0'],
+            'has_vat' => ['required', 'boolean'],
+            'status' => ['required', 'string', Rule::in(Vehicle::STATUSES)],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/VehicleUpdateRequest.php
+++ b/app/Http/Requests/VehicleUpdateRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Vehicle;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class VehicleUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('registration')) {
+            $this->merge([
+                'registration' => strtoupper((string) $this->input('registration')),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $vehicleId = $this->route('vehicle')->id ?? null;
+
+        return [
+            'registration' => [
+                'sometimes',
+                'string',
+                'max:15',
+                'regex:/^[A-Z0-9]+$/',
+                Rule::unique('vehicles', 'registration')->ignore($vehicleId),
+            ],
+            'make' => ['sometimes', 'nullable', 'string', 'max:60'],
+            'model' => ['sometimes', 'nullable', 'string', 'max:60'],
+            'variant' => ['sometimes', 'nullable', 'string', 'max:60'],
+            'year' => ['sometimes', 'nullable', 'integer', 'between:1900,' . (date('Y') + 1)],
+            'mileage' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'mot_expiry' => ['sometimes', 'nullable', 'date'],
+            'road_tax_due' => ['sometimes', 'nullable', 'date'],
+            'purchase_price' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'monthly_finance' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'has_vat' => ['sometimes', 'boolean'],
+            'status' => ['sometimes', 'string', Rule::in(Vehicle::STATUSES)],
+            'notes' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Resources/CustomerResource.php
+++ b/app/Http/Resources/CustomerResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Customer */
+class CustomerResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'type' => $this->type,
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+            'company_name' => $this->company_name,
+            'email' => $this->email,
+            'phone' => $this->phone,
+            'address_line1' => $this->address_line1,
+            'address_line2' => $this->address_line2,
+            'city' => $this->city,
+            'postcode' => $this->postcode,
+            'country' => $this->country,
+            'driving_license_no' => $this->driving_license_no,
+            'dob' => optional($this->dob)?->toDateString(),
+            'nin' => $this->nin,
+            'created_at' => optional($this->created_at)?->toAtomString(),
+            'updated_at' => optional($this->updated_at)?->toAtomString(),
+        ];
+    }
+}

--- a/app/Http/Resources/RentalAgreementResource.php
+++ b/app/Http/Resources/RentalAgreementResource.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\RentalAgreement */
+class RentalAgreementResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'vehicle_id' => $this->vehicle_id,
+            'customer_id' => $this->customer_id,
+            'start_date' => optional($this->start_date)?->toDateString(),
+            'end_date' => optional($this->end_date)?->toDateString(),
+            'billing_cycle' => $this->billing_cycle,
+            'rate_amount' => $this->rate_amount,
+            'deposit_amount' => $this->deposit_amount,
+            'notice_days' => $this->notice_days,
+            'deposit_release_days' => $this->deposit_release_days,
+            'insurance_option' => $this->insurance_option,
+            'mileage_policy' => $this->mileage_policy,
+            'mileage_cap' => $this->mileage_cap,
+            'cleaning_fee' => $this->cleaning_fee,
+            'admin_fee' => $this->admin_fee,
+            'no_smoking' => $this->no_smoking,
+            'tracking_enabled' => $this->tracking_enabled,
+            'payment_day' => $this->payment_day,
+            'status' => $this->status,
+            'created_at' => optional($this->created_at)?->toAtomString(),
+            'updated_at' => optional($this->updated_at)?->toAtomString(),
+            'vehicle' => VehicleResource::make($this->whenLoaded('vehicle')),
+            'customer' => CustomerResource::make($this->whenLoaded('customer')),
+        ];
+    }
+}

--- a/app/Http/Resources/VehicleResource.php
+++ b/app/Http/Resources/VehicleResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Vehicle */
+class VehicleResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'registration' => $this->registration,
+            'make' => $this->make,
+            'model' => $this->model,
+            'variant' => $this->variant,
+            'year' => $this->year,
+            'mileage' => $this->mileage,
+            'mot_expiry' => optional($this->mot_expiry)?->toDateString(),
+            'road_tax_due' => optional($this->road_tax_due)?->toDateString(),
+            'purchase_price' => $this->purchase_price,
+            'monthly_finance' => $this->monthly_finance,
+            'has_vat' => $this->has_vat,
+            'status' => $this->status,
+            'notes' => $this->notes,
+            'created_at' => optional($this->created_at)?->toAtomString(),
+            'updated_at' => optional($this->updated_at)?->toAtomString(),
+        ];
+    }
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -2,15 +2,22 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Customer extends Model
 {
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
+    use HasFactory;
+
+    public const TYPES = [
+        'individual',
+        'sole_trader',
+        'partnership',
+        'ltd',
+        'llp',
+    ];
+
     protected $fillable = [
         'type',
         'first_name',
@@ -27,4 +34,13 @@ class Customer extends Model
         'dob',
         'nin',
     ];
+
+    protected $casts = [
+        'dob' => 'date',
+    ];
+
+    public function rentalAgreements(): HasMany
+    {
+        return $this->hasMany(RentalAgreement::class);
+    }
 }

--- a/app/Models/RentalAgreement.php
+++ b/app/Models/RentalAgreement.php
@@ -2,9 +2,68 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class RentalAgreement extends Model
 {
-    //
+    use HasFactory;
+
+    public const STATUSES = [
+        'draft',
+        'active',
+        'paused',
+        'ended',
+    ];
+
+    public const BILLING_CYCLES = ['weekly', 'monthly'];
+    public const INSURANCE_OPTIONS = ['company', 'own'];
+    public const MILEAGE_POLICIES = ['unlimited', 'cap'];
+    public const PAYMENT_DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
+
+    protected $fillable = [
+        'vehicle_id',
+        'customer_id',
+        'start_date',
+        'end_date',
+        'billing_cycle',
+        'rate_amount',
+        'deposit_amount',
+        'notice_days',
+        'deposit_release_days',
+        'insurance_option',
+        'mileage_policy',
+        'mileage_cap',
+        'cleaning_fee',
+        'admin_fee',
+        'no_smoking',
+        'tracking_enabled',
+        'payment_day',
+        'status',
+    ];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+        'rate_amount' => 'decimal:2',
+        'deposit_amount' => 'decimal:2',
+        'cleaning_fee' => 'decimal:2',
+        'admin_fee' => 'decimal:2',
+        'notice_days' => 'integer',
+        'deposit_release_days' => 'integer',
+        'mileage_cap' => 'integer',
+        'no_smoking' => 'boolean',
+        'tracking_enabled' => 'boolean',
+    ];
+
+    public function vehicle(): BelongsTo
+    {
+        return $this->belongsTo(Vehicle::class);
+    }
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\UserRole;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -10,7 +10,8 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -21,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**
@@ -43,6 +45,12 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'role' => UserRole::class,
         ];
+    }
+
+    public function hasRole(UserRole $role): bool
+    {
+        return $this->role === $role;
     }
 }

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -2,25 +2,56 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Vehicle extends Model
 {
+    use HasFactory;
+
+    public const STATUSES = [
+        'available',
+        'allocated',
+        'maintenance',
+        'offroad',
+        'retired',
+    ];
+
     protected $fillable = [
-        'registration', 'make', 'model', 'variant',
-        'year', 'mileage',
-        'mot_expiry', 'road_tax_due',
-        'purchase_price', 'monthly_finance', 'has_vat',
-        'status', 'notes',
+        'registration',
+        'make',
+        'model',
+        'variant',
+        'year',
+        'mileage',
+        'mot_expiry',
+        'road_tax_due',
+        'purchase_price',
+        'monthly_finance',
+        'has_vat',
+        'status',
+        'notes',
     ];
 
     protected $casts = [
-        'year'           => 'integer',
-        'mileage'        => 'integer',
-        'mot_expiry'     => 'date',
-        'road_tax_due'   => 'date',
+        'year' => 'integer',
+        'mileage' => 'integer',
+        'mot_expiry' => 'date',
+        'road_tax_due' => 'date',
         'purchase_price' => 'decimal:2',
-        'monthly_finance'=> 'decimal:2',
-        'has_vat'        => 'boolean',
+        'monthly_finance' => 'decimal:2',
+        'has_vat' => 'boolean',
     ];
+
+    public function rentalAgreements(): HasMany
+    {
+        return $this->hasMany(RentalAgreement::class);
+    }
+
+    public function activeRental(): HasOne
+    {
+        return $this->hasOne(RentalAgreement::class)->where('status', 'active');
+    }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Customer>
+ */
+class CustomerFactory extends Factory
+{
+    protected $model = Customer::class;
+
+    public function definition(): array
+    {
+        $type = $this->faker->randomElement(Customer::TYPES);
+
+        return [
+            'type' => $type,
+            'first_name' => $type === 'individual' ? $this->faker->firstName() : null,
+            'last_name' => $type === 'individual' ? $this->faker->lastName() : null,
+            'company_name' => $type !== 'individual' ? $this->faker->company() : null,
+            'email' => $this->faker->unique()->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'address_line1' => $this->faker->streetAddress(),
+            'address_line2' => $this->faker->optional()->secondaryAddress(),
+            'city' => $this->faker->city(),
+            'postcode' => $this->faker->postcode(),
+            'country' => 'United Kingdom',
+            'driving_license_no' => $type === 'individual' ? strtoupper($this->faker->bothify('????######??##')) : null,
+            'dob' => $type === 'individual' ? $this->faker->dateTimeBetween('-60 years', '-21 years') : null,
+            'nin' => $type === 'individual' ? strtoupper($this->faker->bothify('??######?')) : null,
+        ];
+    }
+}

--- a/database/factories/RentalAgreementFactory.php
+++ b/database/factories/RentalAgreementFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use App\Models\RentalAgreement;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RentalAgreement>
+ */
+class RentalAgreementFactory extends Factory
+{
+    protected $model = RentalAgreement::class;
+
+    public function definition(): array
+    {
+        $startDate = $this->faker->dateTimeBetween('-1 month', 'now');
+        $billingCycle = $this->faker->randomElement(RentalAgreement::BILLING_CYCLES);
+        $mileagePolicy = $this->faker->randomElement(RentalAgreement::MILEAGE_POLICIES);
+
+        return [
+            'vehicle_id' => Vehicle::factory(),
+            'customer_id' => Customer::factory(),
+            'start_date' => $startDate,
+            'end_date' => $this->faker->optional()->dateTimeBetween($startDate, '+6 months'),
+            'billing_cycle' => $billingCycle,
+            'rate_amount' => $billingCycle === 'weekly'
+                ? $this->faker->randomFloat(2, 250, 600)
+                : $this->faker->randomFloat(2, 900, 2200),
+            'deposit_amount' => $this->faker->randomFloat(2, 250, 1000),
+            'notice_days' => $this->faker->numberBetween(7, 28),
+            'deposit_release_days' => $this->faker->numberBetween(7, 28),
+            'insurance_option' => $this->faker->randomElement(RentalAgreement::INSURANCE_OPTIONS),
+            'mileage_policy' => $mileagePolicy,
+            'mileage_cap' => $mileagePolicy === 'cap' ? $this->faker->numberBetween(500, 2000) : null,
+            'cleaning_fee' => $this->faker->randomFloat(2, 25, 100),
+            'admin_fee' => $this->faker->randomFloat(2, 10, 50),
+            'no_smoking' => $this->faker->boolean(80),
+            'tracking_enabled' => $this->faker->boolean(90),
+            'payment_day' => $this->faker->randomElement(RentalAgreement::PAYMENT_DAYS),
+            'status' => $this->faker->randomElement(RentalAgreement::STATUSES),
+        ];
+    }
+}

--- a/database/factories/VehicleFactory.php
+++ b/database/factories/VehicleFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Vehicle>
+ */
+class VehicleFactory extends Factory
+{
+    protected $model = Vehicle::class;
+
+    public function definition(): array
+    {
+        return [
+            'registration' => strtoupper($this->faker->bothify('??##???')),
+            'make' => $this->faker->randomElement(['Ford', 'Mercedes-Benz', 'Volkswagen', 'Renault']),
+            'model' => $this->faker->randomElement(['Transit', 'Sprinter', 'Crafter', 'Master']),
+            'variant' => $this->faker->word(),
+            'year' => $this->faker->numberBetween(2015, now()->year),
+            'mileage' => $this->faker->numberBetween(10000, 120000),
+            'mot_expiry' => $this->faker->dateTimeBetween('+1 month', '+1 year'),
+            'road_tax_due' => $this->faker->dateTimeBetween('+1 month', '+1 year'),
+            'purchase_price' => $this->faker->randomFloat(2, 15000, 45000),
+            'monthly_finance' => $this->faker->randomFloat(2, 200, 800),
+            'has_vat' => $this->faker->boolean(),
+            'status' => $this->faker->randomElement(Vehicle::STATUSES),
+            'notes' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_10_02_181650_add_role_to_users_table.php
+++ b/database/migrations/2025_10_02_181650_add_role_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Enums\UserRole;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('role')->default(UserRole::CLIENT->value)->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Http\Controllers\Api\CustomerController;
+use App\Http\Controllers\Api\RentalAgreementController;
+use App\Http\Controllers\Api\VehicleController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('v1')->group(function (): void {
+    Route::apiResource('vehicles', VehicleController::class);
+    Route::apiResource('customers', CustomerController::class);
+    Route::apiResource('rental-agreements', RentalAgreementController::class);
+});

--- a/tests/Feature/Api/CustomerApiTest.php
+++ b/tests/Feature/Api/CustomerApiTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CustomerApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_customer_creation_and_update(): void
+    {
+        $payload = [
+            'type' => 'sole_trader',
+            'company_name' => 'LogiRent LTD',
+            'email' => 'ops@example.test',
+            'phone' => '+44 1234 567890',
+            'address_line1' => '10 Downing Street',
+            'city' => 'London',
+            'postcode' => 'SW1A 2AA',
+        ];
+
+        $response = $this->postJson('/api/v1/customers', $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.type', 'sole_trader');
+
+        $customerId = $response->json('data.id');
+
+        $this->assertDatabaseHas('customers', [
+            'id' => $customerId,
+            'email' => 'ops@example.test',
+        ]);
+
+        $updatePayload = [
+            'phone' => '+44 2030 123456',
+            'city' => 'Manchester',
+        ];
+
+        $this->patchJson("/api/v1/customers/{$customerId}", $updatePayload)
+            ->assertOk()
+            ->assertJsonPath('data.city', 'Manchester');
+    }
+}

--- a/tests/Feature/Api/RentalAgreementApiTest.php
+++ b/tests/Feature/Api/RentalAgreementApiTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Customer;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RentalAgreementApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_rental_agreement_lifecycle(): void
+    {
+        $vehicle = Vehicle::factory()->create();
+        $customer = Customer::factory()->create();
+
+        $payload = [
+            'vehicle_id' => $vehicle->id,
+            'customer_id' => $customer->id,
+            'start_date' => '2024-01-01',
+            'billing_cycle' => 'weekly',
+            'rate_amount' => 350,
+            'deposit_amount' => 500,
+            'notice_days' => 14,
+            'deposit_release_days' => 14,
+            'insurance_option' => 'company',
+            'mileage_policy' => 'cap',
+            'mileage_cap' => 1200,
+            'cleaning_fee' => 40,
+            'admin_fee' => 25,
+            'no_smoking' => true,
+            'tracking_enabled' => true,
+            'payment_day' => 'friday',
+            'status' => 'active',
+        ];
+
+        $response = $this->postJson('/api/v1/rental-agreements', $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'active')
+            ->assertJsonPath('data.vehicle_id', $vehicle->id);
+
+        $agreementId = $response->json('data.id');
+
+        $this->patchJson("/api/v1/rental-agreements/{$agreementId}", [
+            'status' => 'ended',
+            'end_date' => '2024-03-01',
+        ])->assertOk()
+            ->assertJsonPath('data.status', 'ended')
+            ->assertJsonPath('data.end_date', '2024-03-01');
+    }
+}

--- a/tests/Feature/Api/VehicleApiTest.php
+++ b/tests/Feature/Api/VehicleApiTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VehicleApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_vehicle_crud_flow(): void
+    {
+        $payload = [
+            'registration' => 'ab12cde',
+            'make' => 'Ford',
+            'model' => 'Transit',
+            'variant' => 'L3H2',
+            'year' => 2022,
+            'mileage' => 15000,
+            'mot_expiry' => '2025-06-01',
+            'road_tax_due' => '2025-05-01',
+            'purchase_price' => 25000,
+            'monthly_finance' => 450.50,
+            'has_vat' => true,
+            'status' => 'available',
+            'notes' => 'EU spec van',
+        ];
+
+        $response = $this->postJson('/api/v1/vehicles', $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.registration', 'AB12CDE');
+
+        $vehicleId = $response->json('data.id');
+
+        $this->assertDatabaseHas('vehicles', [
+            'id' => $vehicleId,
+            'registration' => 'AB12CDE',
+            'status' => 'available',
+        ]);
+
+        $updatePayload = [
+            'mileage' => 18000,
+            'status' => 'allocated',
+        ];
+
+        $this->patchJson("/api/v1/vehicles/{$vehicleId}", $updatePayload)
+            ->assertOk()
+            ->assertJsonPath('data.mileage', 18000)
+            ->assertJsonPath('data.status', 'allocated');
+
+        $this->deleteJson("/api/v1/vehicles/{$vehicleId}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('vehicles', [
+            'id' => $vehicleId,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a role enum and migration to extend the user model for admin, client, and driver personas
- add versioned REST API endpoints with validation, resources, and relationships for vehicles, customers, and rental agreements
- create supporting factories, documentation, and automated tests that cover the core CRUD flows

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68e01ea4c25c832cbcf481c7c44c2229