### PR TITLE
Fix Filament login 403 by allowing all roles

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -58,6 +58,10 @@ class User extends Authenticatable implements FilamentUser
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return $this->hasRole(UserRole::ADMIN);
+        // Permitem tuturor rolurilor definite să acceseze panoul până când
+        // există portaluri dedicate pentru clienți și șoferi. În acest fel
+        // evităm erorile 403 pentru conturile create înainte de introducerea
+        // rolurilor explicite.
+        return in_array($this->role, UserRole::cases(), true);
     }
 }


### PR DESCRIPTION
## Summary
- allow every defined user role to access the Filament admin panel to avoid 403 errors for existing accounts
- document the temporary approach directly in the model for future refinement

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e02765e4a4832cb11d3469a8bdc284