### PR TITLE
feat: expand admin panel for fleet operations

### DIFF
--- a/app/Filament/Resources/Customers/CustomerResource.php
+++ b/app/Filament/Resources/Customers/CustomerResource.php
@@ -5,22 +5,27 @@ namespace App\Filament\Resources\Customers;
 use App\Filament\Resources\Customers\Pages\CreateCustomer;
 use App\Filament\Resources\Customers\Pages\EditCustomer;
 use App\Filament\Resources\Customers\Pages\ListCustomers;
+use App\Filament\Resources\Customers\RelationManagers\FinancialTransactionsRelationManager;
+use App\Filament\Resources\Customers\RelationManagers\RentalAgreementsRelationManager;
 use App\Filament\Resources\Customers\Schemas\CustomerForm;
 use App\Filament\Resources\Customers\Tables\CustomersTable;
 use App\Models\Customer;
 use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
-use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 
 class CustomerResource extends Resource
 {
     protected static ?string $model = Customer::class;
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-users';
 
-    protected static ?string $recordTitleAttribute = 'name';
+    protected static ?string $navigationGroup = 'CRM';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $recordTitleAttribute = 'display_name';
 
     public static function form(Schema $schema): Schema
     {
@@ -35,7 +40,8 @@ class CustomerResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            RentalAgreementsRelationManager::class,
+            FinancialTransactionsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/Customers/RelationManagers/FinancialTransactionsRelationManager.php
+++ b/app/Filament/Resources/Customers/RelationManagers/FinancialTransactionsRelationManager.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Resources\Customers\RelationManagers;
+
+use App\Filament\Resources\FinancialTransactions\Schemas\FinancialTransactionForm;
+use App\Models\FinancialTransaction;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class FinancialTransactionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'financialTransactions';
+
+    protected static ?string $title = 'Financial history';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema(
+            FinancialTransactionForm::getComponents(includeCustomerField: false)
+        );
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('transaction_date', 'desc')
+            ->columns([
+                TextColumn::make('transaction_date')
+                    ->label('Date')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->colors([
+                        'success' => 'income',
+                        'danger' => 'expense',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('category')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline(str_replace('_', ' ', $state)))
+                    ->sortable(),
+                TextColumn::make('amount')
+                    ->money('GBP')
+                    ->sortable(),
+                TextColumn::make('vehicle.registration')
+                    ->label('Vehicle')
+                    ->toggleable(),
+                TextColumn::make('reference')
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options(self::options(FinancialTransaction::TYPES))
+                    ->native(false),
+                SelectFilter::make('category')
+                    ->options(self::options(FinancialTransaction::CATEGORIES))
+                    ->native(false),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline(str_replace('_', ' ', $value))])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/Customers/RelationManagers/RentalAgreementsRelationManager.php
+++ b/app/Filament/Resources/Customers/RelationManagers/RentalAgreementsRelationManager.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Filament\Resources\Customers\RelationManagers;
+
+use App\Filament\Resources\RentalAgreements\Schemas\RentalAgreementForm;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class RentalAgreementsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'rentalAgreements';
+
+    protected static ?string $title = 'Rental agreements';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema(
+            RentalAgreementForm::getComponents(includeCustomerField: false)
+        );
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('start_date', 'desc')
+            ->columns([
+                TextColumn::make('id')
+                    ->label('Contract #')
+                    ->sortable(),
+                TextColumn::make('vehicle.registration')
+                    ->label('Vehicle')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('start_date')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('end_date')
+                    ->date()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('billing_cycle')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('rate_amount')
+                    ->label('Rate')
+                    ->money('GBP')
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->colors([
+                        'success' => 'active',
+                        'warning' => 'paused',
+                        'danger' => 'ended',
+                        'gray' => 'draft',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options([
+                        'active' => 'Active',
+                        'paused' => 'Paused',
+                        'ended' => 'Ended',
+                        'draft' => 'Draft',
+                    ])
+                    ->native(false),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Customers/Schemas/CustomerForm.php
+++ b/app/Filament/Resources/Customers/Schemas/CustomerForm.php
@@ -2,9 +2,13 @@
 
 namespace App\Filament\Resources\Customers\Schemas;
 
+use App\Models\Customer;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
 
 class CustomerForm
 {
@@ -12,27 +16,55 @@ class CustomerForm
     {
         return $schema
             ->components([
-                TextInput::make('type')
-                    ->required()
-                    ->default('individual'),
-                TextInput::make('first_name'),
-                TextInput::make('last_name'),
-                TextInput::make('company_name'),
-                TextInput::make('email')
-                    ->label('Email address')
-                    ->email(),
-                TextInput::make('phone')
-                    ->tel(),
-                TextInput::make('address_line1'),
-                TextInput::make('address_line2'),
-                TextInput::make('city'),
-                TextInput::make('postcode'),
-                TextInput::make('country')
-                    ->required()
-                    ->default('United Kingdom'),
-                TextInput::make('driving_license_no'),
-                DatePicker::make('dob'),
-                TextInput::make('nin'),
+                Section::make('Profile')
+                    ->columns(2)
+                    ->schema([
+                        Select::make('type')
+                            ->options(self::options(Customer::TYPES))
+                            ->default('individual')
+                            ->required()
+                            ->native(false),
+                        TextInput::make('company_name')
+                            ->maxLength(120),
+                        TextInput::make('first_name')
+                            ->maxLength(120),
+                        TextInput::make('last_name')
+                            ->maxLength(120),
+                        DatePicker::make('dob')
+                            ->label('Date of birth'),
+                        TextInput::make('driving_license_no')
+                            ->label('Driving licence'),
+                        TextInput::make('nin')
+                            ->label('National Insurance #')
+                            ->maxLength(20),
+                    ]),
+
+                Section::make('Contact details')
+                    ->columns(2)
+                    ->schema([
+                        TextInput::make('email')
+                            ->label('Email address')
+                            ->email()
+                            ->required(),
+                        TextInput::make('phone')
+                            ->tel(),
+                        TextInput::make('address_line1')
+                            ->label('Address line 1'),
+                        TextInput::make('address_line2')
+                            ->label('Address line 2'),
+                        TextInput::make('city'),
+                        TextInput::make('postcode'),
+                        TextInput::make('country')
+                            ->required()
+                            ->default('United Kingdom'),
+                    ]),
             ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline(str_replace('_', ' ', $value))])
+            ->all();
     }
 }

--- a/app/Filament/Resources/FinancialTransactions/FinancialTransactionResource.php
+++ b/app/Filament/Resources/FinancialTransactions/FinancialTransactionResource.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Resources\FinancialTransactions;
+
+use App\Filament\Resources\FinancialTransactions\Pages\CreateFinancialTransaction;
+use App\Filament\Resources\FinancialTransactions\Pages\EditFinancialTransaction;
+use App\Filament\Resources\FinancialTransactions\Pages\ListFinancialTransactions;
+use App\Filament\Resources\FinancialTransactions\Schemas\FinancialTransactionForm;
+use App\Filament\Resources\FinancialTransactions\Tables\FinancialTransactionsTable;
+use App\Models\FinancialTransaction;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class FinancialTransactionResource extends Resource
+{
+    protected static ?string $model = FinancialTransaction::class;
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-banknotes';
+
+    protected static ?string $navigationGroup = 'Finance';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return FinancialTransactionForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return FinancialTransactionsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListFinancialTransactions::route('/'),
+            'create' => CreateFinancialTransaction::route('/create'),
+            'edit' => EditFinancialTransaction::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/FinancialTransactions/Pages/CreateFinancialTransaction.php
+++ b/app/Filament/Resources/FinancialTransactions/Pages/CreateFinancialTransaction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\FinancialTransactions\Pages;
+
+use App\Filament\Resources\FinancialTransactions\FinancialTransactionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFinancialTransaction extends CreateRecord
+{
+    protected static string $resource = FinancialTransactionResource::class;
+}

--- a/app/Filament/Resources/FinancialTransactions/Pages/EditFinancialTransaction.php
+++ b/app/Filament/Resources/FinancialTransactions/Pages/EditFinancialTransaction.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FinancialTransactions\Pages;
+
+use App\Filament\Resources\FinancialTransactions\FinancialTransactionResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditFinancialTransaction extends EditRecord
+{
+    protected static string $resource = FinancialTransactionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FinancialTransactions/Pages/ListFinancialTransactions.php
+++ b/app/Filament/Resources/FinancialTransactions/Pages/ListFinancialTransactions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FinancialTransactions\Pages;
+
+use App\Filament\Resources\FinancialTransactions\FinancialTransactionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFinancialTransactions extends ListRecords
+{
+    protected static string $resource = FinancialTransactionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FinancialTransactions/Schemas/FinancialTransactionForm.php
+++ b/app/Filament/Resources/FinancialTransactions/Schemas/FinancialTransactionForm.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Filament\Resources\FinancialTransactions\Schemas;
+
+use App\Models\Customer;
+use App\Models\FinancialTransaction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
+
+class FinancialTransactionForm
+{
+    public static function configure(
+        Schema $schema,
+        bool $includeVehicleField = true,
+        bool $includeCustomerField = true
+    ): Schema {
+        return $schema->components(
+            self::getComponents(
+                includeVehicleField: $includeVehicleField,
+                includeCustomerField: $includeCustomerField
+            )
+        );
+    }
+
+    public static function getComponents(
+        bool $includeVehicleField = true,
+        bool $includeCustomerField = true
+    ): array {
+        $associations = [];
+
+        if ($includeVehicleField) {
+            $associations[] = Select::make('vehicle_id')
+                ->relationship('vehicle', 'registration')
+                ->searchable()
+                ->preload()
+                ->native(false);
+        }
+
+        if ($includeCustomerField) {
+            $associations[] = Select::make('customer_id')
+                ->relationship('customer', 'display_name')
+                ->getOptionLabelFromRecordUsing(fn (Customer $record): string => $record->display_name)
+                ->searchable()
+                ->preload()
+                ->native(false);
+        }
+
+        return [
+            Section::make('Transaction details')
+                ->schema([
+                    Select::make('type')
+                        ->options(self::options(FinancialTransaction::TYPES))
+                        ->default('income')
+                        ->required()
+                        ->native(false),
+                    Select::make('category')
+                        ->options(self::options(FinancialTransaction::CATEGORIES))
+                        ->default('rental_income')
+                        ->required()
+                        ->native(false),
+                    DatePicker::make('transaction_date')
+                        ->default(now())
+                        ->required(),
+                    TextInput::make('amount')
+                        ->numeric()
+                        ->prefix('£')
+                        ->required()
+                        ->helperText('Use positive amounts; direction is controlled by the type.'),
+                    TextInput::make('reference')
+                        ->maxLength(120),
+                ])
+                ->columns(2),
+
+            Section::make('Associations')
+                ->schema($associations)
+                ->columns(2),
+
+            Section::make('Notes')
+                ->schema([
+                    Textarea::make('notes')
+                        ->rows(4)
+                        ->columnSpanFull(),
+                ]),
+        ];
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline(str_replace('_', ' ', $value))])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/FinancialTransactions/Tables/FinancialTransactionsTable.php
+++ b/app/Filament/Resources/FinancialTransactions/Tables/FinancialTransactionsTable.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Filament\Resources\FinancialTransactions\Tables;
+
+use App\Models\FinancialTransaction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class FinancialTransactionsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('transaction_date', 'desc')
+            ->columns([
+                TextColumn::make('transaction_date')
+                    ->label('Date')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->colors([
+                        'success' => 'income',
+                        'danger' => 'expense',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('category')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline(str_replace('_', ' ', $state)))
+                    ->sortable(),
+                TextColumn::make('amount')
+                    ->money('GBP')
+                    ->sortable(),
+                TextColumn::make('vehicle.registration')
+                    ->label('Vehicle')
+                    ->searchable()
+                    ->toggleable(),
+                TextColumn::make('customer.display_name')
+                    ->label('Customer')
+                    ->searchable(['customer.company_name', 'customer.first_name', 'customer.last_name'])
+                    ->toggleable(),
+                TextColumn::make('reference')
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->label('Logged at')
+                    ->since()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options(self::options(FinancialTransaction::TYPES))
+                    ->native(false),
+                SelectFilter::make('category')
+                    ->options(self::options(FinancialTransaction::CATEGORIES))
+                    ->native(false),
+                Filter::make('transaction_date')
+                    ->form([
+                        DatePicker::make('from'),
+                        DatePicker::make('until'),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when($data['from'] ?? null, fn (Builder $q, $date): Builder => $q->whereDate('transaction_date', '>=', $date))
+                            ->when($data['until'] ?? null, fn (Builder $q, $date): Builder => $q->whereDate('transaction_date', '<=', $date));
+                    }),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline(str_replace('_', ' ', $value))])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/MaintenanceRecords/MaintenanceRecordResource.php
+++ b/app/Filament/Resources/MaintenanceRecords/MaintenanceRecordResource.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Resources\MaintenanceRecords;
+
+use App\Filament\Resources\MaintenanceRecords\Pages\CreateMaintenanceRecord;
+use App\Filament\Resources\MaintenanceRecords\Pages\EditMaintenanceRecord;
+use App\Filament\Resources\MaintenanceRecords\Pages\ListMaintenanceRecords;
+use App\Filament\Resources\MaintenanceRecords\Schemas\MaintenanceRecordForm;
+use App\Filament\Resources\MaintenanceRecords\Tables\MaintenanceRecordsTable;
+use App\Models\MaintenanceRecord;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class MaintenanceRecordResource extends Resource
+{
+    protected static ?string $model = MaintenanceRecord::class;
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-wrench-screwdriver';
+
+    protected static ?string $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return MaintenanceRecordForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return MaintenanceRecordsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListMaintenanceRecords::route('/'),
+            'create' => CreateMaintenanceRecord::route('/create'),
+            'edit' => EditMaintenanceRecord::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceRecords/Pages/CreateMaintenanceRecord.php
+++ b/app/Filament/Resources/MaintenanceRecords/Pages/CreateMaintenanceRecord.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\MaintenanceRecords\Pages;
+
+use App\Filament\Resources\MaintenanceRecords\MaintenanceRecordResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceRecord extends CreateRecord
+{
+    protected static string $resource = MaintenanceRecordResource::class;
+}

--- a/app/Filament/Resources/MaintenanceRecords/Pages/EditMaintenanceRecord.php
+++ b/app/Filament/Resources/MaintenanceRecords/Pages/EditMaintenanceRecord.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\MaintenanceRecords\Pages;
+
+use App\Filament\Resources\MaintenanceRecords\MaintenanceRecordResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceRecord extends EditRecord
+{
+    protected static string $resource = MaintenanceRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceRecords/Pages/ListMaintenanceRecords.php
+++ b/app/Filament/Resources/MaintenanceRecords/Pages/ListMaintenanceRecords.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\MaintenanceRecords\Pages;
+
+use App\Filament\Resources\MaintenanceRecords\MaintenanceRecordResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceRecords extends ListRecords
+{
+    protected static string $resource = MaintenanceRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceRecords/Schemas/MaintenanceRecordForm.php
+++ b/app/Filament/Resources/MaintenanceRecords/Schemas/MaintenanceRecordForm.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Filament\Resources\MaintenanceRecords\Schemas;
+
+use App\Models\MaintenanceRecord;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
+
+class MaintenanceRecordForm
+{
+    public static function configure(Schema $schema, bool $includeVehicleField = true): Schema
+    {
+        return $schema->components(self::getComponents($includeVehicleField));
+    }
+
+    public static function getComponents(bool $includeVehicleField = true): array
+    {
+        $assignment = [];
+
+        if ($includeVehicleField) {
+            $assignment[] = Select::make('vehicle_id')
+                ->relationship('vehicle', 'registration')
+                ->searchable()
+                ->preload()
+                ->required()
+                ->native(false);
+        }
+
+        $assignment[] = TextInput::make('title')
+            ->required()
+            ->maxLength(120);
+
+        $assignment[] = Select::make('type')
+            ->options(self::options(MaintenanceRecord::TYPES))
+            ->default('service')
+            ->native(false)
+            ->required();
+
+        return [
+            Section::make('Maintenance details')
+                ->schema($assignment)
+                ->columns(2),
+
+            Section::make('Scheduling & progress')
+                ->columns(3)
+                ->schema([
+                    Select::make('status')
+                        ->options(self::options(MaintenanceRecord::STATUSES))
+                        ->default('scheduled')
+                        ->native(false)
+                        ->required(),
+                    DatePicker::make('scheduled_at')
+                        ->label('Scheduled date'),
+                    DatePicker::make('completed_at')
+                        ->label('Completed date'),
+                    TextInput::make('odometer')
+                        ->numeric()
+                        ->suffix('miles'),
+                    TextInput::make('cost')
+                        ->numeric()
+                        ->prefix('£')
+                        ->columnSpan(2),
+                    TextInput::make('vendor')
+                        ->maxLength(120)
+                        ->columnSpan(2),
+                ]),
+
+            Section::make('Notes')
+                ->schema([
+                    Textarea::make('notes')
+                        ->rows(4)
+                        ->columnSpanFull(),
+                ]),
+        ];
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/MaintenanceRecords/Tables/MaintenanceRecordsTable.php
+++ b/app/Filament/Resources/MaintenanceRecords/Tables/MaintenanceRecordsTable.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Resources\MaintenanceRecords\Tables;
+
+use App\Models\MaintenanceRecord;
+use Carbon\Carbon;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class MaintenanceRecordsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('scheduled_at', 'asc')
+            ->columns([
+                TextColumn::make('vehicle.registration')
+                    ->label('Vehicle')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('title')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->colors([
+                        'warning' => 'scheduled',
+                        'info' => 'in_progress',
+                        'success' => 'completed',
+                        'gray' => 'cancelled',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('scheduled_at')
+                    ->label('Scheduled')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('completed_at')
+                    ->label('Completed')
+                    ->date()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('cost')
+                    ->money('GBP')
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(self::options(MaintenanceRecord::STATUSES))
+                    ->native(false),
+                SelectFilter::make('type')
+                    ->options(self::options(MaintenanceRecord::TYPES))
+                    ->native(false),
+                Filter::make('due_soon')
+                    ->label('Due within 14 days')
+                    ->query(
+                        fn (Builder $query): Builder => $query
+                            ->whereIn('status', ['scheduled', 'in_progress'])
+                            ->whereBetween('scheduled_at', [
+                                Carbon::now()->startOfDay(),
+                                Carbon::now()->addDays(14)->endOfDay(),
+                            ])
+                    ),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/RentalAgreements/Pages/CreateRentalAgreement.php
+++ b/app/Filament/Resources/RentalAgreements/Pages/CreateRentalAgreement.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\RentalAgreements\Pages;
+
+use App\Filament\Resources\RentalAgreements\RentalAgreementResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRentalAgreement extends CreateRecord
+{
+    protected static string $resource = RentalAgreementResource::class;
+}

--- a/app/Filament/Resources/RentalAgreements/Pages/EditRentalAgreement.php
+++ b/app/Filament/Resources/RentalAgreements/Pages/EditRentalAgreement.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\RentalAgreements\Pages;
+
+use App\Filament\Resources\RentalAgreements\RentalAgreementResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRentalAgreement extends EditRecord
+{
+    protected static string $resource = RentalAgreementResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/RentalAgreements/Pages/ListRentalAgreements.php
+++ b/app/Filament/Resources/RentalAgreements/Pages/ListRentalAgreements.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\RentalAgreements\Pages;
+
+use App\Filament\Resources\RentalAgreements\RentalAgreementResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRentalAgreements extends ListRecords
+{
+    protected static string $resource = RentalAgreementResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/RentalAgreements/RentalAgreementResource.php
+++ b/app/Filament/Resources/RentalAgreements/RentalAgreementResource.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\RentalAgreements;
+
+use App\Filament\Resources\RentalAgreements\Pages\CreateRentalAgreement;
+use App\Filament\Resources\RentalAgreements\Pages\EditRentalAgreement;
+use App\Filament\Resources\RentalAgreements\Pages\ListRentalAgreements;
+use App\Filament\Resources\RentalAgreements\Schemas\RentalAgreementForm;
+use App\Filament\Resources\RentalAgreements\Tables\RentalAgreementsTable;
+use App\Models\RentalAgreement;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class RentalAgreementResource extends Resource
+{
+    protected static ?string $model = RentalAgreement::class;
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-check';
+
+    protected static ?string $navigationGroup = 'Fleet Operations';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static ?string $recordTitleAttribute = 'id';
+
+    public static function form(Schema $schema): Schema
+    {
+        return RentalAgreementForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return RentalAgreementsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListRentalAgreements::route('/'),
+            'create' => CreateRentalAgreement::route('/create'),
+            'edit' => EditRentalAgreement::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/RentalAgreements/Schemas/RentalAgreementForm.php
+++ b/app/Filament/Resources/RentalAgreements/Schemas/RentalAgreementForm.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Filament\Resources\RentalAgreements\Schemas;
+
+use App\Models\Customer;
+use App\Models\RentalAgreement;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Get;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
+
+class RentalAgreementForm
+{
+    public static function configure(
+        Schema $schema,
+        bool $includeVehicleField = true,
+        bool $includeCustomerField = true
+    ): Schema {
+        return $schema->components(
+            self::getComponents(
+                includeVehicleField: $includeVehicleField,
+                includeCustomerField: $includeCustomerField
+            )
+        );
+    }
+
+    public static function getComponents(
+        bool $includeVehicleField = true,
+        bool $includeCustomerField = true
+    ): array {
+        $assignment = [];
+
+        if ($includeVehicleField) {
+            $assignment[] = Select::make('vehicle_id')
+                ->relationship('vehicle', 'registration')
+                ->searchable()
+                ->preload()
+                ->required()
+                ->native(false);
+        }
+
+        if ($includeCustomerField) {
+            $assignment[] = Select::make('customer_id')
+                ->relationship('customer', 'display_name')
+                ->getOptionLabelFromRecordUsing(
+                    fn (Customer $record): string => $record->display_name
+                )
+                ->searchable()
+                ->preload()
+                ->required()
+                ->native(false);
+        }
+
+        $assignment[] = DatePicker::make('start_date')
+            ->required();
+
+        $assignment[] = DatePicker::make('end_date')
+            ->helperText('Optional. Leave blank for open-ended contracts.');
+
+        return [
+            Section::make('Assignment')
+                ->schema($assignment)
+                ->columns(2),
+
+            Section::make('Commercial Terms')
+                ->columns(3)
+                ->schema([
+                    Select::make('billing_cycle')
+                        ->options(self::options(RentalAgreement::BILLING_CYCLES))
+                        ->default('weekly')
+                        ->native(false)
+                        ->required(),
+                    TextInput::make('rate_amount')
+                        ->label('Rate amount')
+                        ->numeric()
+                        ->prefix('£')
+                        ->required(),
+                    TextInput::make('deposit_amount')
+                        ->label('Deposit')
+                        ->numeric()
+                        ->default(500)
+                        ->prefix('£'),
+                    TextInput::make('notice_days')
+                        ->numeric()
+                        ->default(14)
+                        ->label('Notice period (days)'),
+                    TextInput::make('deposit_release_days')
+                        ->numeric()
+                        ->default(14)
+                        ->label('Deposit release (days)'),
+                    Select::make('payment_day')
+                        ->options(self::options(RentalAgreement::PAYMENT_DAYS))
+                        ->default('friday')
+                        ->native(false),
+                ]),
+
+            Section::make('Policies & Coverage')
+                ->columns(3)
+                ->schema([
+                    Select::make('insurance_option')
+                        ->options(self::options(RentalAgreement::INSURANCE_OPTIONS))
+                        ->default('company')
+                        ->native(false),
+                    Select::make('mileage_policy')
+                        ->options(self::options(RentalAgreement::MILEAGE_POLICIES))
+                        ->default('unlimited')
+                        ->native(false),
+                    TextInput::make('mileage_cap')
+                        ->numeric()
+                        ->suffix('miles')
+                        ->visible(fn (Get $get): bool => $get('mileage_policy') === 'cap')
+                        ->required(fn (Get $get): bool => $get('mileage_policy') === 'cap'),
+                    TextInput::make('cleaning_fee')
+                        ->numeric()
+                        ->prefix('£')
+                        ->default(50),
+                    TextInput::make('admin_fee')
+                        ->numeric()
+                        ->prefix('£')
+                        ->default(25),
+                    Toggle::make('no_smoking')
+                        ->inline(false)
+                        ->default(true),
+                    Toggle::make('tracking_enabled')
+                        ->inline(false)
+                        ->default(true),
+                    Select::make('status')
+                        ->options(self::options(RentalAgreement::STATUSES))
+                        ->default('active')
+                        ->native(false)
+                        ->columnSpanFull(),
+                ]),
+
+        ];
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/RentalAgreements/Tables/RentalAgreementsTable.php
+++ b/app/Filament/Resources/RentalAgreements/Tables/RentalAgreementsTable.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Filament\Resources\RentalAgreements\Tables;
+
+use App\Models\RentalAgreement;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class RentalAgreementsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('start_date', 'desc')
+            ->columns([
+                TextColumn::make('id')
+                    ->label('Contract #')
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('vehicle.registration')
+                    ->label('Vehicle')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('customer.display_name')
+                    ->label('Customer')
+                    ->searchable(['customer.company_name', 'customer.first_name', 'customer.last_name'])
+                    ->toggleable(),
+                TextColumn::make('start_date')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('end_date')
+                    ->date()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('billing_cycle')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('rate_amount')
+                    ->label('Rate')
+                    ->money('GBP')
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->colors([
+                        'success' => 'active',
+                        'warning' => 'paused',
+                        'danger' => 'ended',
+                        'gray' => 'draft',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(self::optionLabels(RentalAgreement::STATUSES))
+                    ->native(false),
+                SelectFilter::make('billing_cycle')
+                    ->label('Billing cycle')
+                    ->options(self::optionLabels(RentalAgreement::BILLING_CYCLES))
+                    ->native(false),
+                TernaryFilter::make('active')
+                    ->label('Active agreements')
+                    ->queries(
+                        true: fn (Builder $query): Builder => $query->where('status', 'active'),
+                        false: fn (Builder $query): Builder => $query->where('status', '!=', 'active'),
+                    ),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ]);
+    }
+
+    private static function optionLabels(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/Vehicles/RelationManagers/FinancialTransactionsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/FinancialTransactionsRelationManager.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Resources\Vehicles\RelationManagers;
+
+use App\Filament\Resources\FinancialTransactions\Schemas\FinancialTransactionForm;
+use App\Models\FinancialTransaction;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class FinancialTransactionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'financialTransactions';
+
+    protected static ?string $title = 'Financial ledger';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema(
+            FinancialTransactionForm::getComponents(includeVehicleField: false)
+        );
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('transaction_date', 'desc')
+            ->columns([
+                TextColumn::make('transaction_date')
+                    ->label('Date')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->colors([
+                        'success' => 'income',
+                        'danger' => 'expense',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('category')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline(str_replace('_', ' ', $state)))
+                    ->sortable(),
+                TextColumn::make('amount')
+                    ->money('GBP')
+                    ->sortable(),
+                TextColumn::make('customer.display_name')
+                    ->label('Customer')
+                    ->toggleable(),
+                TextColumn::make('reference')
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options(self::options(FinancialTransaction::TYPES))
+                    ->native(false),
+                SelectFilter::make('category')
+                    ->options(self::options(FinancialTransaction::CATEGORIES))
+                    ->native(false),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline(str_replace('_', ' ', $value))])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/Vehicles/RelationManagers/MaintenanceRecordsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/MaintenanceRecordsRelationManager.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Resources\Vehicles\RelationManagers;
+
+use App\Filament\Resources\MaintenanceRecords\Schemas\MaintenanceRecordForm;
+use App\Models\MaintenanceRecord;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class MaintenanceRecordsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'maintenanceRecords';
+
+    protected static ?string $title = 'Maintenance history';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema(
+            MaintenanceRecordForm::getComponents(includeVehicleField: false)
+        );
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('scheduled_at')
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->colors([
+                        'warning' => 'scheduled',
+                        'info' => 'in_progress',
+                        'success' => 'completed',
+                        'gray' => 'cancelled',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('scheduled_at')
+                    ->label('Scheduled')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('completed_at')
+                    ->label('Completed')
+                    ->date()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('cost')
+                    ->money('GBP')
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(self::options(MaintenanceRecord::STATUSES))
+                    ->native(false),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/Vehicles/RelationManagers/RentalAgreementsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/RentalAgreementsRelationManager.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Filament\Resources\Vehicles\RelationManagers;
+
+use App\Filament\Resources\RentalAgreements\Schemas\RentalAgreementForm;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class RentalAgreementsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'rentalAgreements';
+
+    protected static ?string $title = 'Rental agreements';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema(
+            RentalAgreementForm::getComponents(includeVehicleField: false)
+        );
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('start_date', 'desc')
+            ->columns([
+                TextColumn::make('id')
+                    ->label('Contract #')
+                    ->sortable(),
+                TextColumn::make('customer.display_name')
+                    ->label('Customer')
+                    ->searchable(['customer.company_name', 'customer.first_name', 'customer.last_name'])
+                    ->sortable(),
+                TextColumn::make('start_date')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('end_date')
+                    ->date()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('rate_amount')
+                    ->label('Rate')
+                    ->money('GBP')
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->colors([
+                        'success' => 'active',
+                        'warning' => 'paused',
+                        'danger' => 'ended',
+                        'gray' => 'draft',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options([
+                        'active' => 'Active',
+                        'paused' => 'Paused',
+                        'ended' => 'Ended',
+                        'draft' => 'Draft',
+                    ])
+                    ->native(false),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Vehicles/Schemas/VehicleForm.php
+++ b/app/Filament/Resources/Vehicles/Schemas/VehicleForm.php
@@ -2,12 +2,14 @@
 
 namespace App\Filament\Resources\Vehicles\Schemas;
 
-use Filament\Schemas\Schema;
-use Filament\Forms\Components\TextInput;
+use App\Models\Vehicle;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
 
 class VehicleForm
 {
@@ -44,13 +46,13 @@ class VehicleForm
 
             // Status
             Select::make('status')
-                ->options([
-                    'available'   => 'Available',
-                    'rented'      => 'Rented',
-                    'maintenance' => 'Maintenance',
-                    'reserved'    => 'Reserved',
-                ])
-                ->default('available'),
+                ->options(
+                    collect(Vehicle::STATUSES)
+                        ->mapWithKeys(fn (string $status) => [$status => Str::headline($status)])
+                        ->all()
+                )
+                ->default('available')
+                ->native(false),
 
             // Notes
             Textarea::make('notes'),

--- a/app/Filament/Resources/Vehicles/Tables/VehiclesTable.php
+++ b/app/Filament/Resources/Vehicles/Tables/VehiclesTable.php
@@ -2,12 +2,14 @@
 
 namespace App\Filament\Resources\Vehicles\Tables;
 
-use Filament\Tables\Table;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Actions\EditAction;
+use App\Models\Vehicle;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
 
 class VehiclesTable
 {
@@ -34,6 +36,14 @@ class VehiclesTable
 
                 TextColumn::make('status')
                     ->badge()
+                    ->colors([
+                        'success' => 'available',
+                        'warning' => 'reserved',
+                        'info' => 'allocated',
+                        'danger' => 'maintenance',
+                        'gray' => 'offroad',
+                    ])
+                    ->formatStateUsing(fn (string $state) => Str::headline($state))
                     ->sortable()
                     ->toggleable(),
 
@@ -56,12 +66,11 @@ class VehiclesTable
             ->filters([
                 SelectFilter::make('status')
                     ->label('Status')
-                    ->options([
-                        'available'   => 'Available',
-                        'rented'      => 'Rented',
-                        'maintenance' => 'Maintenance',
-                        'reserved'    => 'Reserved',
-                    ])
+                    ->options(
+                        collect(Vehicle::STATUSES)
+                            ->mapWithKeys(fn (string $status) => [$status => Str::headline($status)])
+                            ->all()
+                    )
                     ->native(false),
             ])
             ->recordActions([

--- a/app/Filament/Resources/Vehicles/VehicleResource.php
+++ b/app/Filament/Resources/Vehicles/VehicleResource.php
@@ -5,20 +5,26 @@ namespace App\Filament\Resources\Vehicles;
 use App\Filament\Resources\Vehicles\Pages\CreateVehicle;
 use App\Filament\Resources\Vehicles\Pages\EditVehicle;
 use App\Filament\Resources\Vehicles\Pages\ListVehicles;
+use App\Filament\Resources\Vehicles\RelationManagers\FinancialTransactionsRelationManager;
+use App\Filament\Resources\Vehicles\RelationManagers\MaintenanceRecordsRelationManager;
+use App\Filament\Resources\Vehicles\RelationManagers\RentalAgreementsRelationManager;
 use App\Filament\Resources\Vehicles\Schemas\VehicleForm;
 use App\Filament\Resources\Vehicles\Tables\VehiclesTable;
 use App\Models\Vehicle;
 use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
-use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 
 class VehicleResource extends Resource
 {
     protected static ?string $model = Vehicle::class;
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-truck';
+
+    protected static ?string $navigationGroup = 'Fleet Operations';
+
+    protected static ?int $navigationSort = 1;
 
     protected static ?string $recordTitleAttribute = 'registration';
 
@@ -35,7 +41,9 @@ class VehicleResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            RentalAgreementsRelationManager::class,
+            MaintenanceRecordsRelationManager::class,
+            FinancialTransactionsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Widgets/FleetStatsOverview.php
+++ b/app/Filament/Widgets/FleetStatsOverview.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\FinancialTransaction;
+use App\Models\MaintenanceRecord;
+use App\Models\RentalAgreement;
+use App\Models\Vehicle;
+use Carbon\Carbon;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Number;
+
+class FleetStatsOverview extends StatsOverviewWidget
+{
+    protected function getStats(): array
+    {
+        $totalVehicles = Vehicle::count();
+        $availableVehicles = Vehicle::where('status', 'available')->count();
+        $activeAgreements = RentalAgreement::where('status', 'active')->count();
+        $maintenanceInProgress = MaintenanceRecord::whereIn('status', ['scheduled', 'in_progress'])->count();
+
+        $occupancy = $totalVehicles > 0
+            ? round(($activeAgreements / $totalVehicles) * 100)
+            : 0;
+
+        $periodStart = Carbon::now()->startOfMonth();
+        $periodEnd = Carbon::now()->endOfMonth();
+
+        $monthlyIncome = FinancialTransaction::where('type', 'income')
+            ->whereBetween('transaction_date', [$periodStart, $periodEnd])
+            ->sum('amount');
+
+        $monthlyExpenses = FinancialTransaction::where('type', 'expense')
+            ->whereBetween('transaction_date', [$periodStart, $periodEnd])
+            ->sum('amount');
+
+        $netCashflow = $monthlyIncome - $monthlyExpenses;
+
+        return [
+            Stat::make('Fleet vehicles', Number::format($totalVehicles))
+                ->description(Number::format($availableVehicles) . ' available')
+                ->descriptionIcon('heroicon-m-truck')
+                ->color('primary'),
+
+            Stat::make('Active rentals', Number::format($activeAgreements))
+                ->description($occupancy . '% fleet occupancy')
+                ->descriptionIcon('heroicon-m-chart-pie')
+                ->color($occupancy >= 80 ? 'success' : 'warning'),
+
+            Stat::make('Open maintenance', Number::format($maintenanceInProgress))
+                ->description('Scheduled or in progress')
+                ->descriptionIcon('heroicon-m-wrench-screwdriver')
+                ->color($maintenanceInProgress === 0 ? 'success' : 'danger'),
+
+            Stat::make('Net cashflow (month)', Number::currency($netCashflow, 'GBP'))
+                ->description(
+                    'Income ' . Number::currency($monthlyIncome, 'GBP') . ' / Expenses ' . Number::currency($monthlyExpenses, 'GBP')
+                )
+                ->descriptionIcon('heroicon-m-banknotes')
+                ->color($netCashflow >= 0 ? 'success' : 'danger'),
+        ];
+    }
+}

--- a/app/Filament/Widgets/UpcomingMaintenance.php
+++ b/app/Filament/Widgets/UpcomingMaintenance.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\MaintenanceRecord;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class UpcomingMaintenance extends TableWidget
+{
+    protected static ?string $heading = 'Upcoming maintenance';
+
+    protected int|string|array $columnSpan = 'full';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query($this->query())
+            ->columns([
+                TextColumn::make('vehicle.registration')
+                    ->label('Vehicle')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('title')
+                    ->sortable()
+                    ->limit(40),
+                TextColumn::make('scheduled_at')
+                    ->label('Scheduled')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->colors([
+                        'warning' => 'scheduled',
+                        'info' => 'in_progress',
+                        'success' => 'completed',
+                    ])
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state)),
+                TextColumn::make('vendor')
+                    ->toggleable(),
+            ])
+            ->paginated(false);
+    }
+
+    protected function query(): Builder
+    {
+        return MaintenanceRecord::query()
+            ->with('vehicle')
+            ->whereIn('status', ['scheduled', 'in_progress'])
+            ->orderByRaw('scheduled_at IS NULL')
+            ->orderBy('scheduled_at')
+            ->limit(8);
+    }
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Customer extends Model
 {
@@ -42,5 +43,22 @@ class Customer extends Model
     public function rentalAgreements(): HasMany
     {
         return $this->hasMany(RentalAgreement::class);
+    }
+
+    public function financialTransactions(): HasMany
+    {
+        return $this->hasMany(FinancialTransaction::class);
+    }
+
+    public function activeRental(): HasOne
+    {
+        return $this->hasOne(RentalAgreement::class)->where('status', 'active');
+    }
+
+    public function getDisplayNameAttribute(): string
+    {
+        $fullName = trim(collect([$this->first_name, $this->last_name])->filter()->join(' '));
+
+        return $this->company_name ?: ($fullName !== '' ? $fullName : $this->email);
     }
 }

--- a/app/Models/FinancialTransaction.php
+++ b/app/Models/FinancialTransaction.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FinancialTransaction extends Model
+{
+    use HasFactory;
+
+    public const TYPES = [
+        'income',
+        'expense',
+    ];
+
+    public const CATEGORIES = [
+        'rental_income',
+        'deposit',
+        'maintenance',
+        'fuel',
+        'insurance',
+        'fine',
+        'other',
+    ];
+
+    protected $fillable = [
+        'type',
+        'category',
+        'reference',
+        'amount',
+        'transaction_date',
+        'vehicle_id',
+        'customer_id',
+        'notes',
+    ];
+
+    protected $casts = [
+        'transaction_date' => 'date',
+        'amount' => 'decimal:2',
+    ];
+
+    public function vehicle(): BelongsTo
+    {
+        return $this->belongsTo(Vehicle::class);
+    }
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+}

--- a/app/Models/MaintenanceRecord.php
+++ b/app/Models/MaintenanceRecord.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class MaintenanceRecord extends Model
+{
+    use HasFactory;
+
+    public const TYPES = [
+        'service',
+        'inspection',
+        'repair',
+        'mot',
+        'road_tax',
+        'valeting',
+        'other',
+    ];
+
+    public const STATUSES = [
+        'scheduled',
+        'in_progress',
+        'completed',
+        'cancelled',
+    ];
+
+    protected $fillable = [
+        'vehicle_id',
+        'title',
+        'type',
+        'status',
+        'odometer',
+        'scheduled_at',
+        'completed_at',
+        'cost',
+        'vendor',
+        'notes',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'date',
+        'completed_at' => 'date',
+        'cost' => 'decimal:2',
+    ];
+
+    public function vehicle(): BelongsTo
+    {
+        return $this->belongsTo(Vehicle::class);
+    }
+}

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -15,6 +15,7 @@ class Vehicle extends Model
         'available',
         'allocated',
         'maintenance',
+        'reserved',
         'offroad',
         'retired',
     ];
@@ -53,5 +54,15 @@ class Vehicle extends Model
     public function activeRental(): HasOne
     {
         return $this->hasOne(RentalAgreement::class)->where('status', 'active');
+    }
+
+    public function maintenanceRecords(): HasMany
+    {
+        return $this->hasMany(MaintenanceRecord::class);
+    }
+
+    public function financialTransactions(): HasMany
+    {
+        return $this->hasMany(FinancialTransaction::class);
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Widgets\FleetStatsOverview;
+use App\Filament\Widgets\UpcomingMaintenance;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -11,7 +13,6 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use Filament\Widgets\AccountWidget;
-use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -39,7 +40,8 @@ class AdminPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
             ->widgets([
                 AccountWidget::class,
-                FilamentInfoWidget::class,
+                FleetStatsOverview::class,
+                UpcomingMaintenance::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/database/migrations/2025_10_02_181651_create_maintenance_records_table.php
+++ b/database/migrations/2025_10_02_181651_create_maintenance_records_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('maintenance_records', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('vehicle_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->string('type', 40);
+            $table->string('status', 30)->default('scheduled')->index();
+            $table->unsignedInteger('odometer')->nullable();
+            $table->date('scheduled_at')->nullable()->index();
+            $table->date('completed_at')->nullable();
+            $table->decimal('cost', 10, 2)->nullable();
+            $table->string('vendor', 120)->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_records');
+    }
+};

--- a/database/migrations/2025_10_02_181652_create_financial_transactions_table.php
+++ b/database/migrations/2025_10_02_181652_create_financial_transactions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('financial_transactions', function (Blueprint $table): void {
+            $table->id();
+            $table->string('type', 20); // income | expense
+            $table->string('category', 60);
+            $table->string('reference', 120)->nullable();
+            $table->decimal('amount', 10, 2);
+            $table->date('transaction_date')->index();
+            $table->foreignId('vehicle_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('customer_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('financial_transactions');
+    }
+};


### PR DESCRIPTION
## Summary
- add dedicated Filament resources for rental agreements, maintenance records, and financial transactions to cover core Ame Rentals workflows
- extend vehicles and customers with relation managers, richer tables, and updated forms for better fleet and client oversight
- introduce maintenance and finance data models plus dashboard widgets and migrations to support end-to-end fleet management

## Testing
- not run (dependencies not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e028a0ce74832ca49f2c6505238e1b