### PR TITLE
Fix Filament relation manager forms for v4 compatibility

### DIFF
--- a/app/Filament/Resources/Customers/RelationManagers/FinancialTransactionsRelationManager.php
+++ b/app/Filament/Resources/Customers/RelationManagers/FinancialTransactionsRelationManager.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\Customers\RelationManagers;
 
 use App\Filament\Resources\FinancialTransactions\Schemas\FinancialTransactionForm;
 use App\Models\FinancialTransaction;
-use Filament\Forms\Form;
+use Filament\Schemas\Schema;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
@@ -20,10 +20,11 @@ class FinancialTransactionsRelationManager extends RelationManager
 
     protected static ?string $title = 'Financial history';
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form->schema(
-            FinancialTransactionForm::getComponents(includeCustomerField: false)
+        return FinancialTransactionForm::configure(
+            $schema,
+            includeCustomerField: false
         );
     }
 

--- a/app/Filament/Resources/Customers/RelationManagers/RentalAgreementsRelationManager.php
+++ b/app/Filament/Resources/Customers/RelationManagers/RentalAgreementsRelationManager.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\Customers\RelationManagers;
 
 use App\Filament\Resources\RentalAgreements\Schemas\RentalAgreementForm;
-use Filament\Forms\Form;
+use Filament\Schemas\Schema;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
@@ -19,10 +19,11 @@ class RentalAgreementsRelationManager extends RelationManager
 
     protected static ?string $title = 'Rental agreements';
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form->schema(
-            RentalAgreementForm::getComponents(includeCustomerField: false)
+        return RentalAgreementForm::configure(
+            $schema,
+            includeCustomerField: false
         );
     }
 

--- a/app/Filament/Resources/Vehicles/RelationManagers/FinancialTransactionsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/FinancialTransactionsRelationManager.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\Vehicles\RelationManagers;
 
 use App\Filament\Resources\FinancialTransactions\Schemas\FinancialTransactionForm;
 use App\Models\FinancialTransaction;
-use Filament\Forms\Form;
+use Filament\Schemas\Schema;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
@@ -20,10 +20,11 @@ class FinancialTransactionsRelationManager extends RelationManager
 
     protected static ?string $title = 'Financial ledger';
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form->schema(
-            FinancialTransactionForm::getComponents(includeVehicleField: false)
+        return FinancialTransactionForm::configure(
+            $schema,
+            includeVehicleField: false
         );
     }
 

--- a/app/Filament/Resources/Vehicles/RelationManagers/MaintenanceRecordsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/MaintenanceRecordsRelationManager.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\Vehicles\RelationManagers;
 
 use App\Filament\Resources\MaintenanceRecords\Schemas\MaintenanceRecordForm;
 use App\Models\MaintenanceRecord;
-use Filament\Forms\Form;
+use Filament\Schemas\Schema;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
@@ -20,10 +20,11 @@ class MaintenanceRecordsRelationManager extends RelationManager
 
     protected static ?string $title = 'Maintenance history';
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form->schema(
-            MaintenanceRecordForm::getComponents(includeVehicleField: false)
+        return MaintenanceRecordForm::configure(
+            $schema,
+            includeVehicleField: false
         );
     }
 

--- a/app/Filament/Resources/Vehicles/RelationManagers/RentalAgreementsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/RentalAgreementsRelationManager.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\Vehicles\RelationManagers;
 
 use App\Filament\Resources\RentalAgreements\Schemas\RentalAgreementForm;
-use Filament\Forms\Form;
+use Filament\Schemas\Schema;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
@@ -19,10 +19,11 @@ class RentalAgreementsRelationManager extends RelationManager
 
     protected static ?string $title = 'Rental agreements';
 
-    public function form(Form $form): Form
+    public function form(Schema $schema): Schema
     {
-        return $form->schema(
-            RentalAgreementForm::getComponents(includeVehicleField: false)
+        return RentalAgreementForm::configure(
+            $schema,
+            includeVehicleField: false
         );
     }
 


### PR DESCRIPTION
## Summary
- update relation manager form signatures to the Filament 4 `Schema` API
- delegate to shared form configurators instead of manually building schemas

## Testing
- php -l app/Filament/Resources/Customers/RelationManagers/FinancialTransactionsRelationManager.php
- php -l app/Filament/Resources/Customers/RelationManagers/RentalAgreementsRelationManager.php
- php -l app/Filament/Resources/Vehicles/RelationManagers/FinancialTransactionsRelationManager.php
- php -l app/Filament/Resources/Vehicles/RelationManagers/MaintenanceRecordsRelationManager.php
- php -l app/Filament/Resources/Vehicles/RelationManagers/RentalAgreementsRelationManager.php

------
https://chatgpt.com/codex/tasks/task_e_68e0320e4c5c832c82d2e5c568d0fe7b