### PR TITLE
Fix navigation group type in financial transaction resource

### DIFF
--- a/app/Filament/Resources/FinancialTransactions/FinancialTransactionResource.php
+++ b/app/Filament/Resources/FinancialTransactions/FinancialTransactionResource.php
@@ -12,6 +12,7 @@ use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
+use UnitEnum;
 
 class FinancialTransactionResource extends Resource
 {
@@ -19,7 +20,7 @@ class FinancialTransactionResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-banknotes';
 
-    protected static ?string $navigationGroup = 'Finance';
+    protected static string|UnitEnum|null $navigationGroup = 'Finance';
 
     protected static ?int $navigationSort = 1;
 


### PR DESCRIPTION
## Summary
- import UnitEnum for Filament resource type compatibility
- update FinancialTransactionResource::$navigationGroup to use the expected UnitEnum|string|null type

## Testing
- php -l app/Filament/Resources/FinancialTransactions/FinancialTransactionResource.php

------
https://chatgpt.com/codex/tasks/task_e_68e033c37218832cbe7e66bd70644d35