### PR TITLE
Fix navigation group typing for maintenance record resource

### DIFF
--- a/app/Filament/Resources/MaintenanceRecords/MaintenanceRecordResource.php
+++ b/app/Filament/Resources/MaintenanceRecords/MaintenanceRecordResource.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\MaintenanceRecords\Schemas\MaintenanceRecordForm;
 use App\Filament\Resources\MaintenanceRecords\Tables\MaintenanceRecordsTable;
 use App\Models\MaintenanceRecord;
 use BackedEnum;
+use UnitEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
@@ -19,7 +20,7 @@ class MaintenanceRecordResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-wrench-screwdriver';
 
-    protected static ?string $navigationGroup = 'Maintenance';
+    protected static string|UnitEnum|null $navigationGroup = 'Maintenance';
 
     protected static ?int $navigationSort = 1;
 


### PR DESCRIPTION
## Summary
- allow the maintenance record resource navigation group property to accept enums as expected by Filament

## Testing
- php -l app/Filament/Resources/MaintenanceRecords/MaintenanceRecordResource.php

------
https://chatgpt.com/codex/tasks/task_e_68e0359519f0832cb5b3bd57012be096