### PR TITLE
Fix Filament section imports for v4 compatibility

### DIFF
--- a/app/Filament/Resources/Customers/Schemas/CustomerForm.php
+++ b/app/Filament/Resources/Customers/Schemas/CustomerForm.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\Customers\Schemas;
 
 use App\Models\Customer;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;

--- a/app/Filament/Resources/FinancialTransactions/Schemas/FinancialTransactionForm.php
+++ b/app/Filament/Resources/FinancialTransactions/Schemas/FinancialTransactionForm.php
@@ -5,7 +5,7 @@ namespace App\Filament\Resources\FinancialTransactions\Schemas;
 use App\Models\Customer;
 use App\Models\FinancialTransaction;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;

--- a/app/Filament/Resources/MaintenanceRecords/Schemas/MaintenanceRecordForm.php
+++ b/app/Filament/Resources/MaintenanceRecords/Schemas/MaintenanceRecordForm.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\MaintenanceRecords\Schemas;
 
 use App\Models\MaintenanceRecord;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;

--- a/app/Filament/Resources/RentalAgreements/Schemas/RentalAgreementForm.php
+++ b/app/Filament/Resources/RentalAgreements/Schemas/RentalAgreementForm.php
@@ -5,7 +5,7 @@ namespace App\Filament\Resources\RentalAgreements\Schemas;
 use App\Models\Customer;
 use App\Models\RentalAgreement;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;


### PR DESCRIPTION
## Summary
- update Filament form schemas to use the new Section component namespace introduced in Filament v4 so resource forms load correctly

## Testing
- APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68e0401486d8832c811d0ea6706e9c76