### PR TITLE
Add vehicle inspection tracking for van checks

### DIFF
--- a/app/Filament/Resources/VehicleInspections/Pages/CreateVehicleInspection.php
+++ b/app/Filament/Resources/VehicleInspections/Pages/CreateVehicleInspection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\VehicleInspections\Pages;
+
+use App\Filament\Resources\VehicleInspections\VehicleInspectionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateVehicleInspection extends CreateRecord
+{
+    protected static string $resource = VehicleInspectionResource::class;
+}

--- a/app/Filament/Resources/VehicleInspections/Pages/EditVehicleInspection.php
+++ b/app/Filament/Resources/VehicleInspections/Pages/EditVehicleInspection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\VehicleInspections\Pages;
+
+use App\Filament\Resources\VehicleInspections\VehicleInspectionResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditVehicleInspection extends EditRecord
+{
+    protected static string $resource = VehicleInspectionResource::class;
+}

--- a/app/Filament/Resources/VehicleInspections/Pages/ListVehicleInspections.php
+++ b/app/Filament/Resources/VehicleInspections/Pages/ListVehicleInspections.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\VehicleInspections\Pages;
+
+use App\Filament\Resources\VehicleInspections\VehicleInspectionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListVehicleInspections extends ListRecords
+{
+    protected static string $resource = VehicleInspectionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/VehicleInspections/Schemas/VehicleInspectionForm.php
+++ b/app/Filament/Resources/VehicleInspections/Schemas/VehicleInspectionForm.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Resources\VehicleInspections\Schemas;
+
+use App\Models\VehicleInspection;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
+
+class VehicleInspectionForm
+{
+    public static function configure(Schema $schema, bool $includeVehicleField = true): Schema
+    {
+        return $schema->components(self::getComponents($includeVehicleField));
+    }
+
+    public static function getComponents(bool $includeVehicleField = true): array
+    {
+        $details = [];
+
+        if ($includeVehicleField) {
+            $details[] = Select::make('vehicle_id')
+                ->relationship('vehicle', 'registration')
+                ->searchable()
+                ->preload()
+                ->required()
+                ->native(false);
+        }
+
+        $details[] = Select::make('type')
+            ->options(self::options(VehicleInspection::TYPES))
+            ->required()
+            ->native(false)
+            ->default('onhire');
+
+        $details[] = DatePicker::make('inspected_at')
+            ->label('Inspection date')
+            ->required();
+
+        return [
+            Section::make('Inspection details')
+                ->schema($details)
+                ->columns(3),
+
+            Section::make('Condition photos')
+                ->columns(3)
+                ->schema([
+                    self::photoUpload('front_image_path', 'Front'),
+                    self::photoUpload('left_image_path', 'Left side'),
+                    self::photoUpload('right_image_path', 'Right side'),
+                    self::photoUpload('rear_image_path', 'Rear'),
+                    self::photoUpload('tyres_image_path', 'Tyres'),
+                    self::photoUpload('windscreen_image_path', 'Windscreen'),
+                    self::photoUpload('mirrors_image_path', 'Mirrors'),
+                ]),
+
+            Section::make('Notes')
+                ->schema([
+                    Textarea::make('notes')
+                        ->rows(4)
+                        ->columnSpanFull(),
+                ]),
+        ];
+    }
+
+    private static function photoUpload(string $name, string $label): FileUpload
+    {
+        return FileUpload::make($name)
+            ->label($label)
+            ->image()
+            ->directory('vehicle-inspections')
+            ->disk('public')
+            ->required();
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/VehicleInspections/Tables/VehicleInspectionsTable.php
+++ b/app/Filament/Resources/VehicleInspections/Tables/VehicleInspectionsTable.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Resources\VehicleInspections\Tables;
+
+use App\Models\VehicleInspection;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class VehicleInspectionsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('inspected_at', 'desc')
+            ->columns([
+                TextColumn::make('vehicle.registration')
+                    ->label('Vehicle')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('inspected_at')
+                    ->label('Inspected on')
+                    ->date()
+                    ->sortable(),
+                ImageColumn::make('front_image_path')
+                    ->label('Front')
+                    ->disk('public')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->label('Logged at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options(self::options(VehicleInspection::TYPES))
+                    ->native(false),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/VehicleInspections/VehicleInspectionResource.php
+++ b/app/Filament/Resources/VehicleInspections/VehicleInspectionResource.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Resources\VehicleInspections;
+
+use App\Filament\Resources\VehicleInspections\Pages\CreateVehicleInspection;
+use App\Filament\Resources\VehicleInspections\Pages\EditVehicleInspection;
+use App\Filament\Resources\VehicleInspections\Pages\ListVehicleInspections;
+use App\Filament\Resources\VehicleInspections\Schemas\VehicleInspectionForm;
+use App\Filament\Resources\VehicleInspections\Tables\VehicleInspectionsTable;
+use App\Models\VehicleInspection;
+use BackedEnum;
+use UnitEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class VehicleInspectionResource extends Resource
+{
+    protected static ?string $model = VehicleInspection::class;
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-camera';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Fleet Operations';
+
+    protected static ?int $navigationSort = 4;
+
+    protected static ?string $modelLabel = 'Vehicle inspection';
+
+    protected static ?string $pluralModelLabel = 'Vehicle inspections';
+
+    public static function form(Schema $schema): Schema
+    {
+        return VehicleInspectionForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return VehicleInspectionsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListVehicleInspections::route('/'),
+            'create' => CreateVehicleInspection::route('/create'),
+            'edit' => EditVehicleInspection::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Vehicles/RelationManagers/VehicleInspectionsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/VehicleInspectionsRelationManager.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Filament\Resources\Vehicles\RelationManagers;
+
+use App\Filament\Resources\VehicleInspections\Schemas\VehicleInspectionForm;
+use App\Models\VehicleInspection;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class VehicleInspectionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'inspections';
+
+    protected static ?string $title = 'Inspection history';
+
+    public function form(Schema $schema): Schema
+    {
+        return VehicleInspectionForm::configure(
+            $schema,
+            includeVehicleField: false
+        );
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('inspected_at', 'desc')
+            ->columns([
+                TextColumn::make('type')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->sortable(),
+                TextColumn::make('inspected_at')
+                    ->label('Inspected on')
+                    ->date()
+                    ->sortable(),
+                ImageColumn::make('front_image_path')
+                    ->label('Front')
+                    ->disk('public')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->label('Logged at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options(self::options(VehicleInspection::TYPES))
+                    ->native(false),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+
+    private static function options(array $values): array
+    {
+        return collect($values)
+            ->mapWithKeys(fn (string $value): array => [$value => Str::headline($value)])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/Vehicles/VehicleResource.php
+++ b/app/Filament/Resources/Vehicles/VehicleResource.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\Vehicles\Pages\ListVehicles;
 use App\Filament\Resources\Vehicles\RelationManagers\FinancialTransactionsRelationManager;
 use App\Filament\Resources\Vehicles\RelationManagers\MaintenanceRecordsRelationManager;
 use App\Filament\Resources\Vehicles\RelationManagers\RentalAgreementsRelationManager;
+use App\Filament\Resources\Vehicles\RelationManagers\VehicleInspectionsRelationManager;
 use App\Filament\Resources\Vehicles\Schemas\VehicleForm;
 use App\Filament\Resources\Vehicles\Tables\VehiclesTable;
 use App\Models\Vehicle;
@@ -45,6 +46,7 @@ class VehicleResource extends Resource
             RentalAgreementsRelationManager::class,
             MaintenanceRecordsRelationManager::class,
             FinancialTransactionsRelationManager::class,
+            VehicleInspectionsRelationManager::class,
         ];
     }
 

--- a/app/Http/Controllers/Api/VehicleInspectionController.php
+++ b/app/Http/Controllers/Api/VehicleInspectionController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\VehicleInspectionStoreRequest;
+use App\Http\Requests\VehicleInspectionUpdateRequest;
+use App\Http\Resources\VehicleInspectionResource;
+use App\Models\VehicleInspection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+class VehicleInspectionController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $inspections = VehicleInspection::query()
+            ->latest('inspected_at')
+            ->with('vehicle:id,registration')
+            ->paginate(perPage: request('per_page', 15));
+
+        return VehicleInspectionResource::collection($inspections);
+    }
+
+    public function store(VehicleInspectionStoreRequest $request): JsonResponse
+    {
+        $inspection = VehicleInspection::create($request->validated());
+
+        $inspection->load('vehicle:id,registration');
+
+        return VehicleInspectionResource::make($inspection)
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(VehicleInspection $vehicleInspection): VehicleInspectionResource
+    {
+        $vehicleInspection->loadMissing('vehicle:id,registration');
+
+        return VehicleInspectionResource::make($vehicleInspection);
+    }
+
+    public function update(
+        VehicleInspectionUpdateRequest $request,
+        VehicleInspection $vehicleInspection
+    ): VehicleInspectionResource {
+        $vehicleInspection->fill($request->validated());
+        $vehicleInspection->save();
+
+        $vehicleInspection->loadMissing('vehicle:id,registration');
+
+        return VehicleInspectionResource::make($vehicleInspection);
+    }
+
+    public function destroy(VehicleInspection $vehicleInspection): JsonResponse
+    {
+        $vehicleInspection->delete();
+
+        return response()->json(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Requests/VehicleInspectionStoreRequest.php
+++ b/app/Http/Requests/VehicleInspectionStoreRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\VehicleInspection;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class VehicleInspectionStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'vehicle_id' => ['required', 'exists:vehicles,id'],
+            'type' => ['required', Rule::in(VehicleInspection::TYPES)],
+            'inspected_at' => ['required', 'date'],
+            'notes' => ['nullable', 'string'],
+            'front_image_path' => ['required', 'string', 'max:255'],
+            'rear_image_path' => ['required', 'string', 'max:255'],
+            'left_image_path' => ['required', 'string', 'max:255'],
+            'right_image_path' => ['required', 'string', 'max:255'],
+            'tyres_image_path' => ['required', 'string', 'max:255'],
+            'windscreen_image_path' => ['required', 'string', 'max:255'],
+            'mirrors_image_path' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/VehicleInspectionUpdateRequest.php
+++ b/app/Http/Requests/VehicleInspectionUpdateRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\VehicleInspection;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class VehicleInspectionUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'vehicle_id' => ['sometimes', 'exists:vehicles,id'],
+            'type' => ['sometimes', Rule::in(VehicleInspection::TYPES)],
+            'inspected_at' => ['sometimes', 'date'],
+            'notes' => ['sometimes', 'nullable', 'string'],
+            'front_image_path' => ['sometimes', 'string', 'max:255'],
+            'rear_image_path' => ['sometimes', 'string', 'max:255'],
+            'left_image_path' => ['sometimes', 'string', 'max:255'],
+            'right_image_path' => ['sometimes', 'string', 'max:255'],
+            'tyres_image_path' => ['sometimes', 'string', 'max:255'],
+            'windscreen_image_path' => ['sometimes', 'string', 'max:255'],
+            'mirrors_image_path' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Resources/VehicleInspectionResource.php
+++ b/app/Http/Resources/VehicleInspectionResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\VehicleInspection */
+class VehicleInspectionResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'vehicle_id' => $this->vehicle_id,
+            'type' => $this->type,
+            'inspected_at' => optional($this->inspected_at)?->toDateString(),
+            'notes' => $this->notes,
+            'vehicle' => $this->whenLoaded('vehicle', fn (): array => [
+                'id' => $this->vehicle?->id,
+                'registration' => $this->vehicle?->registration,
+            ]),
+            'front_image_path' => $this->front_image_path,
+            'rear_image_path' => $this->rear_image_path,
+            'left_image_path' => $this->left_image_path,
+            'right_image_path' => $this->right_image_path,
+            'tyres_image_path' => $this->tyres_image_path,
+            'windscreen_image_path' => $this->windscreen_image_path,
+            'mirrors_image_path' => $this->mirrors_image_path,
+            'created_at' => optional($this->created_at)?->toAtomString(),
+            'updated_at' => optional($this->updated_at)?->toAtomString(),
+        ];
+    }
+}

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -65,4 +65,9 @@ class Vehicle extends Model
     {
         return $this->hasMany(FinancialTransaction::class);
     }
+
+    public function inspections(): HasMany
+    {
+        return $this->hasMany(VehicleInspection::class);
+    }
 }

--- a/app/Models/VehicleInspection.php
+++ b/app/Models/VehicleInspection.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class VehicleInspection extends Model
+{
+    use HasFactory;
+
+    public const TYPES = [
+        'onhire',
+        'weekly',
+    ];
+
+    protected $fillable = [
+        'vehicle_id',
+        'type',
+        'inspected_at',
+        'notes',
+        'front_image_path',
+        'rear_image_path',
+        'left_image_path',
+        'right_image_path',
+        'tyres_image_path',
+        'windscreen_image_path',
+        'mirrors_image_path',
+    ];
+
+    protected $casts = [
+        'inspected_at' => 'date',
+    ];
+
+    public function vehicle(): BelongsTo
+    {
+        return $this->belongsTo(Vehicle::class);
+    }
+}

--- a/database/factories/VehicleInspectionFactory.php
+++ b/database/factories/VehicleInspectionFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Vehicle;
+use App\Models\VehicleInspection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<VehicleInspection>
+ */
+class VehicleInspectionFactory extends Factory
+{
+    protected $model = VehicleInspection::class;
+
+    public function definition(): array
+    {
+        return [
+            'vehicle_id' => Vehicle::factory(),
+            'type' => $this->faker->randomElement(VehicleInspection::TYPES),
+            'inspected_at' => $this->faker->date(),
+            'notes' => $this->faker->optional()->sentence(),
+            'front_image_path' => 'vehicle-inspections/front/' . $this->faker->uuid . '.jpg',
+            'rear_image_path' => 'vehicle-inspections/rear/' . $this->faker->uuid . '.jpg',
+            'left_image_path' => 'vehicle-inspections/left/' . $this->faker->uuid . '.jpg',
+            'right_image_path' => 'vehicle-inspections/right/' . $this->faker->uuid . '.jpg',
+            'tyres_image_path' => 'vehicle-inspections/tyres/' . $this->faker->uuid . '.jpg',
+            'windscreen_image_path' => 'vehicle-inspections/windscreen/' . $this->faker->uuid . '.jpg',
+            'mirrors_image_path' => 'vehicle-inspections/mirrors/' . $this->faker->uuid . '.jpg',
+        ];
+    }
+}

--- a/database/migrations/2025_10_02_181653_create_vehicle_inspections_table.php
+++ b/database/migrations/2025_10_02_181653_create_vehicle_inspections_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vehicle_inspections', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('vehicle_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 20);
+            $table->date('inspected_at');
+            $table->string('front_image_path');
+            $table->string('rear_image_path');
+            $table->string('left_image_path');
+            $table->string('right_image_path');
+            $table->string('tyres_image_path');
+            $table->string('windscreen_image_path');
+            $table->string('mirrors_image_path');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->index(['vehicle_id', 'type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vehicle_inspections');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\CustomerController;
 use App\Http\Controllers\Api\RentalAgreementController;
+use App\Http\Controllers\Api\VehicleInspectionController;
 use App\Http\Controllers\Api\VehicleController;
 use Illuminate\Support\Facades\Route;
 
@@ -9,4 +10,5 @@ Route::prefix('v1')->group(function (): void {
     Route::apiResource('vehicles', VehicleController::class);
     Route::apiResource('customers', CustomerController::class);
     Route::apiResource('rental-agreements', RentalAgreementController::class);
+    Route::apiResource('vehicle-inspections', VehicleInspectionController::class);
 });

--- a/tests/Feature/Api/VehicleInspectionApiTest.php
+++ b/tests/Feature/Api/VehicleInspectionApiTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VehicleInspectionApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_vehicle_inspection_crud_flow(): void
+    {
+        $vehicle = Vehicle::factory()->create();
+
+        $payload = [
+            'vehicle_id' => $vehicle->id,
+            'type' => 'onhire',
+            'inspected_at' => '2025-02-01',
+            'notes' => 'On-hire inspection for new contract',
+            'front_image_path' => 'vehicle-inspections/front/front.jpg',
+            'rear_image_path' => 'vehicle-inspections/rear/rear.jpg',
+            'left_image_path' => 'vehicle-inspections/left/left.jpg',
+            'right_image_path' => 'vehicle-inspections/right/right.jpg',
+            'tyres_image_path' => 'vehicle-inspections/tyres/tyres.jpg',
+            'windscreen_image_path' => 'vehicle-inspections/windscreen/windscreen.jpg',
+            'mirrors_image_path' => 'vehicle-inspections/mirrors/mirrors.jpg',
+        ];
+
+        $response = $this->postJson('/api/v1/vehicle-inspections', $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.type', 'onhire')
+            ->assertJsonPath('data.vehicle_id', $vehicle->id);
+
+        $inspectionId = $response->json('data.id');
+
+        $this->assertDatabaseHas('vehicle_inspections', [
+            'id' => $inspectionId,
+            'vehicle_id' => $vehicle->id,
+            'type' => 'onhire',
+        ]);
+
+        $updatePayload = [
+            'type' => 'weekly',
+            'notes' => 'Weekly inspection captured',
+            'mirrors_image_path' => 'vehicle-inspections/mirrors/updated.jpg',
+        ];
+
+        $this->patchJson("/api/v1/vehicle-inspections/{$inspectionId}", $updatePayload)
+            ->assertOk()
+            ->assertJsonPath('data.type', 'weekly')
+            ->assertJsonPath('data.notes', 'Weekly inspection captured')
+            ->assertJsonPath('data.mirrors_image_path', 'vehicle-inspections/mirrors/updated.jpg');
+
+        $this->deleteJson("/api/v1/vehicle-inspections/{$inspectionId}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('vehicle_inspections', [
+            'id' => $inspectionId,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a vehicle inspections domain model with mandatory photo evidence for on-hire and weekly van checks
- expose REST API endpoints, validation, and feature tests for recording inspection details and image paths
- add Filament resource pages and vehicle relation manager to capture and review inspection photos in the admin panel

## Testing
- php artisan test *(fails: vendor directory missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e045590850832cae0e1a4fcf70899a