### PR TITLE
Add profit and loss reporting endpoint

### DIFF
--- a/app/Http/Controllers/Api/FinancialReportController.php
+++ b/app/Http/Controllers/Api/FinancialReportController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ProfitAndLossRequest;
+use App\Models\FinancialTransaction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+
+class FinancialReportController extends Controller
+{
+    public function __invoke(ProfitAndLossRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+        $startDate = $validated['start_date'];
+        $endDate = $validated['end_date'];
+
+        $query = FinancialTransaction::query()
+            ->whereBetween('transaction_date', [$startDate, $endDate]);
+
+        $typeTotals = (clone $query)
+            ->selectRaw('type, SUM(amount) as total')
+            ->groupBy('type')
+            ->pluck('total', 'type');
+
+        $categoryBreakdown = (clone $query)
+            ->selectRaw('type, category, SUM(amount) as total')
+            ->groupBy('type', 'category')
+            ->get()
+            ->groupBy('type')
+            ->map(fn (Collection $rows) => $rows
+                ->sortBy('category')
+                ->mapWithKeys(fn ($row) => [
+                    $row->category => round((float) $row->total, 2),
+                ])
+                ->all()
+            );
+
+        $incomeTotal = round((float) ($typeTotals['income'] ?? 0), 2);
+        $expenseTotal = round((float) ($typeTotals['expense'] ?? 0), 2);
+        $netTotal = round($incomeTotal - $expenseTotal, 2);
+
+        return response()->json([
+            'data' => [
+                'period' => [
+                    'start_date' => $startDate,
+                    'end_date' => $endDate,
+                ],
+                'totals' => [
+                    'income' => $incomeTotal,
+                    'expenses' => $expenseTotal,
+                    'net' => $netTotal,
+                ],
+                'breakdown' => [
+                    'income' => $categoryBreakdown->get('income', []),
+                    'expenses' => $categoryBreakdown->get('expense', []),
+                ],
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/ProfitAndLossRequest.php
+++ b/app/Http/Requests/ProfitAndLossRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Carbon;
+
+class ProfitAndLossRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('year')) {
+            $year = (int) $this->input('year');
+
+            $this->merge([
+                'start_date' => $this->input('start_date') ?? Carbon::create($year, 1, 1)->toDateString(),
+                'end_date' => $this->input('end_date') ?? Carbon::create($year, 12, 31)->toDateString(),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'year' => ['nullable', 'integer', 'between:2000,' . (date('Y') + 5)],
+            'start_date' => ['required_without:year', 'date'],
+            'end_date' => ['required_with:start_date', 'date', 'after_or_equal:start_date'],
+        ];
+    }
+}

--- a/database/factories/FinancialTransactionFactory.php
+++ b/database/factories/FinancialTransactionFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FinancialTransaction;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\FinancialTransaction>
+ */
+class FinancialTransactionFactory extends Factory
+{
+    protected $model = FinancialTransaction::class;
+
+    public function definition(): array
+    {
+        $type = $this->faker->randomElement(FinancialTransaction::TYPES);
+
+        return [
+            'type' => $type,
+            'category' => $this->faker->randomElement(FinancialTransaction::CATEGORIES),
+            'reference' => $this->faker->boolean(70) ? $this->faker->bothify('REF-####') : null,
+            'amount' => $this->faker->randomFloat(2, 25, 2500),
+            'transaction_date' => $this->faker->dateTimeBetween('-2 years', 'now')->format('Y-m-d'),
+            'vehicle_id' => null,
+            'customer_id' => null,
+            'notes' => $this->faker->boolean(30) ? $this->faker->sentence() : null,
+        ];
+    }
+
+    public function income(): self
+    {
+        return $this->state(fn () => [
+            'type' => 'income',
+        ]);
+    }
+
+    public function expense(): self
+    {
+        return $this->state(fn () => [
+            'type' => 'expense',
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\CustomerController;
+use App\Http\Controllers\Api\FinancialReportController;
 use App\Http\Controllers\Api\RentalAgreementController;
 use App\Http\Controllers\Api\VehicleInspectionController;
 use App\Http\Controllers\Api\VehicleController;
@@ -11,4 +12,5 @@ Route::prefix('v1')->group(function (): void {
     Route::apiResource('customers', CustomerController::class);
     Route::apiResource('rental-agreements', RentalAgreementController::class);
     Route::apiResource('vehicle-inspections', VehicleInspectionController::class);
+    Route::get('reports/profit-and-loss', FinancialReportController::class)->name('reports.profit-and-loss');
 });

--- a/tests/Feature/Api/FinancialReportApiTest.php
+++ b/tests/Feature/Api/FinancialReportApiTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\FinancialTransaction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FinancialReportApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_profit_and_loss_report_returns_expected_totals_for_period(): void
+    {
+        FinancialTransaction::factory()->create([
+            'type' => 'income',
+            'category' => 'rental_income',
+            'amount' => 1500,
+            'transaction_date' => '2024-03-10',
+        ]);
+
+        FinancialTransaction::factory()->create([
+            'type' => 'income',
+            'category' => 'rental_income',
+            'amount' => 500,
+            'transaction_date' => '2024-07-02',
+        ]);
+
+        FinancialTransaction::factory()->create([
+            'type' => 'expense',
+            'category' => 'maintenance',
+            'amount' => 400,
+            'transaction_date' => '2024-04-18',
+        ]);
+
+        FinancialTransaction::factory()->create([
+            'type' => 'expense',
+            'category' => 'fuel',
+            'amount' => 100,
+            'transaction_date' => '2024-05-05',
+        ]);
+
+        // Outside of the selected period and should be ignored.
+        FinancialTransaction::factory()->create([
+            'type' => 'income',
+            'category' => 'rental_income',
+            'amount' => 999,
+            'transaction_date' => '2023-12-31',
+        ]);
+
+        $response = $this->getJson('/api/v1/reports/profit-and-loss?start_date=2024-01-01&end_date=2024-12-31');
+
+        $response->assertOk()
+            ->assertJsonPath('data.period.start_date', '2024-01-01')
+            ->assertJsonPath('data.period.end_date', '2024-12-31')
+            ->assertJsonPath('data.totals.income', 2000)
+            ->assertJsonPath('data.totals.expenses', 500)
+            ->assertJsonPath('data.totals.net', 1500)
+            ->assertJsonPath('data.breakdown.income.rental_income', 2000)
+            ->assertJsonPath('data.breakdown.expenses.maintenance', 400)
+            ->assertJsonPath('data.breakdown.expenses.fuel', 100);
+    }
+
+    public function test_profit_and_loss_report_can_infer_period_from_year(): void
+    {
+        FinancialTransaction::factory()->income()->create([
+            'category' => 'rental_income',
+            'amount' => 250,
+            'transaction_date' => '2025-01-15',
+        ]);
+
+        $response = $this->getJson('/api/v1/reports/profit-and-loss?year=2025');
+
+        $response->assertOk()
+            ->assertJsonPath('data.period.start_date', '2025-01-01')
+            ->assertJsonPath('data.period.end_date', '2025-12-31')
+            ->assertJsonPath('data.totals.income', 250)
+            ->assertJsonPath('data.totals.expenses', 0)
+            ->assertJsonPath('data.totals.net', 250);
+    }
+
+    public function test_profit_and_loss_validation_errors_are_reported(): void
+    {
+        $this->getJson('/api/v1/reports/profit-and-loss')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['start_date']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a profit and loss API endpoint that aggregates totals and category breakdowns for a given period
- add request validation that accepts explicit dates or infers them from a year parameter
- provide a financial transaction factory and feature tests for the new reporting endpoint

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68e2806cb2d8832c9c377aee268a8412