### PR TITLE
Fix dotenv parsing by quoting app name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=AME Rentals
+APP_NAME="AME Rentals"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true


### PR DESCRIPTION
## Summary
- wrap the APP_NAME value in quotes so dotenv can parse the application name containing a space

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e28cda6f48832c922d33f961ed9c25