### PR TITLE
Expand financial transaction categories

### DIFF
--- a/app/Filament/Resources/Customers/RelationManagers/FinancialTransactionsRelationManager.php
+++ b/app/Filament/Resources/Customers/RelationManagers/FinancialTransactionsRelationManager.php
@@ -63,8 +63,9 @@ class FinancialTransactionsRelationManager extends RelationManager
                     ->options(self::options(FinancialTransaction::TYPES))
                     ->native(false),
                 SelectFilter::make('category')
-                    ->options(self::options(FinancialTransaction::CATEGORIES))
-                    ->native(false),
+                    ->options(self::options(FinancialTransaction::categories()))
+                    ->native(false)
+                    ->searchable(),
             ])
             ->headerActions([
                 CreateAction::make(),

--- a/app/Filament/Resources/FinancialTransactions/Schemas/FinancialTransactionForm.php
+++ b/app/Filament/Resources/FinancialTransactions/Schemas/FinancialTransactionForm.php
@@ -5,6 +5,8 @@ namespace App\Filament\Resources\FinancialTransactions\Schemas;
 use App\Models\Customer;
 use App\Models\FinancialTransaction;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
 use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -55,14 +57,21 @@ class FinancialTransactionForm
                 ->schema([
                     Select::make('type')
                         ->options(self::options(FinancialTransaction::TYPES))
-                        ->default('income')
+                        ->default(FinancialTransaction::TYPES[0])
                         ->required()
-                        ->native(false),
+                        ->native(false)
+                        ->live()
+                        ->afterStateUpdated(function (Set $set, ?string $state): void {
+                            $set('category', FinancialTransaction::defaultCategory($state));
+                        }),
                     Select::make('category')
-                        ->options(self::options(FinancialTransaction::CATEGORIES))
-                        ->default('rental_income')
+                        ->options(fn (Get $get): array => self::options(
+                            FinancialTransaction::categories($get('type'))
+                        ))
+                        ->default(FinancialTransaction::defaultCategory())
                         ->required()
-                        ->native(false),
+                        ->native(false)
+                        ->searchable(),
                     DatePicker::make('transaction_date')
                         ->default(now())
                         ->required(),

--- a/app/Filament/Resources/FinancialTransactions/Tables/FinancialTransactionsTable.php
+++ b/app/Filament/Resources/FinancialTransactions/Tables/FinancialTransactionsTable.php
@@ -58,8 +58,9 @@ class FinancialTransactionsTable
                     ->options(self::options(FinancialTransaction::TYPES))
                     ->native(false),
                 SelectFilter::make('category')
-                    ->options(self::options(FinancialTransaction::CATEGORIES))
-                    ->native(false),
+                    ->options(self::options(FinancialTransaction::categories()))
+                    ->native(false)
+                    ->searchable(),
                 Filter::make('transaction_date')
                     ->form([
                         DatePicker::make('from'),

--- a/app/Filament/Resources/Vehicles/RelationManagers/FinancialTransactionsRelationManager.php
+++ b/app/Filament/Resources/Vehicles/RelationManagers/FinancialTransactionsRelationManager.php
@@ -63,8 +63,9 @@ class FinancialTransactionsRelationManager extends RelationManager
                     ->options(self::options(FinancialTransaction::TYPES))
                     ->native(false),
                 SelectFilter::make('category')
-                    ->options(self::options(FinancialTransaction::CATEGORIES))
-                    ->native(false),
+                    ->options(self::options(FinancialTransaction::categories()))
+                    ->native(false)
+                    ->searchable(),
             ])
             ->headerActions([
                 CreateAction::make(),

--- a/app/Models/FinancialTransaction.php
+++ b/app/Models/FinancialTransaction.php
@@ -15,14 +15,94 @@ class FinancialTransaction extends Model
         'expense',
     ];
 
+    public const CATEGORY_GROUPS = [
+        'income' => [
+            'rental_income',
+            'deposit_received',
+            'damage_recharge',
+            'insurance_recharge',
+            'late_fee_income',
+            'additional_mileage',
+            'accessory_hire',
+            'vehicle_sale',
+            'other_income',
+        ],
+        'expense' => [
+            'maintenance',
+            'repairs',
+            'tyres',
+            'fuel',
+            'insurance',
+            'road_tax',
+            'mot',
+            'breakdown_cover',
+            'vehicle_purchase',
+            'vehicle_finance_payment',
+            'vehicle_lease',
+            'vehicle_registration',
+            'deposit_refund',
+            'valeting',
+            'cleaning_supplies',
+            'parking',
+            'tolls',
+            'fine',
+            'wages',
+            'subcontractor_costs',
+            'marketing',
+            'software',
+            'office_rent',
+            'utilities',
+            'accountancy',
+            'legal',
+            'bank_charges',
+            'interest',
+            'training',
+            'travel',
+            'other_expense',
+        ],
+    ];
+
     public const CATEGORIES = [
         'rental_income',
-        'deposit',
+        'deposit_received',
+        'damage_recharge',
+        'insurance_recharge',
+        'late_fee_income',
+        'additional_mileage',
+        'accessory_hire',
+        'vehicle_sale',
+        'other_income',
         'maintenance',
+        'repairs',
+        'tyres',
         'fuel',
         'insurance',
+        'road_tax',
+        'mot',
+        'breakdown_cover',
+        'vehicle_purchase',
+        'vehicle_finance_payment',
+        'vehicle_lease',
+        'vehicle_registration',
+        'deposit_refund',
+        'valeting',
+        'cleaning_supplies',
+        'parking',
+        'tolls',
         'fine',
-        'other',
+        'wages',
+        'subcontractor_costs',
+        'marketing',
+        'software',
+        'office_rent',
+        'utilities',
+        'accountancy',
+        'legal',
+        'bank_charges',
+        'interest',
+        'training',
+        'travel',
+        'other_expense',
     ];
 
     protected $fillable = [
@@ -40,6 +120,30 @@ class FinancialTransaction extends Model
         'transaction_date' => 'date',
         'amount' => 'decimal:2',
     ];
+
+    public static function categories(?string $type = null): array
+    {
+        if ($type !== null && array_key_exists($type, self::CATEGORY_GROUPS)) {
+            return self::CATEGORY_GROUPS[$type];
+        }
+
+        $groups = array_values(self::CATEGORY_GROUPS);
+
+        if ($groups === []) {
+            return [];
+        }
+
+        return array_values(array_unique(array_merge(...$groups)));
+    }
+
+    public static function defaultCategory(?string $type = null): ?string
+    {
+        $type ??= self::TYPES[0];
+
+        $categories = self::categories($type);
+
+        return $categories[0] ?? null;
+    }
 
     public function vehicle(): BelongsTo
     {

--- a/database/factories/FinancialTransactionFactory.php
+++ b/database/factories/FinancialTransactionFactory.php
@@ -18,7 +18,7 @@ class FinancialTransactionFactory extends Factory
 
         return [
             'type' => $type,
-            'category' => $this->faker->randomElement(FinancialTransaction::CATEGORIES),
+            'category' => $this->faker->randomElement(FinancialTransaction::categories($type)),
             'reference' => $this->faker->boolean(70) ? $this->faker->bothify('REF-####') : null,
             'amount' => $this->faker->randomFloat(2, 25, 2500),
             'transaction_date' => $this->faker->dateTimeBetween('-2 years', 'now')->format('Y-m-d'),
@@ -32,6 +32,7 @@ class FinancialTransactionFactory extends Factory
     {
         return $this->state(fn () => [
             'type' => 'income',
+            'category' => fake()->randomElement(FinancialTransaction::categories('income')),
         ]);
     }
 
@@ -39,6 +40,7 @@ class FinancialTransactionFactory extends Factory
     {
         return $this->state(fn () => [
             'type' => 'expense',
+            'category' => fake()->randomElement(FinancialTransaction::categories('expense')),
         ]);
     }
 }

--- a/tests/Unit/FinancialTransactionCategoriesTest.php
+++ b/tests/Unit/FinancialTransactionCategoriesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\FinancialTransaction;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class FinancialTransactionCategoriesTest extends TestCase
+{
+    #[Test]
+    public function it_returns_categories_for_each_type(): void
+    {
+        $this->assertSame(
+            FinancialTransaction::CATEGORY_GROUPS['income'],
+            FinancialTransaction::categories('income')
+        );
+
+        $this->assertSame(
+            FinancialTransaction::CATEGORY_GROUPS['expense'],
+            FinancialTransaction::categories('expense')
+        );
+    }
+
+    #[Test]
+    public function it_returns_a_merged_list_when_type_not_provided(): void
+    {
+        $merged = FinancialTransaction::categories();
+        $expected = array_values(array_unique(array_merge(
+            FinancialTransaction::CATEGORY_GROUPS['income'],
+            FinancialTransaction::CATEGORY_GROUPS['expense'],
+        )));
+
+        $this->assertSame($expected, $merged);
+    }
+
+    #[Test]
+    public function it_exposes_default_categories_for_each_type(): void
+    {
+        $this->assertSame('rental_income', FinancialTransaction::defaultCategory());
+        $this->assertSame('maintenance', FinancialTransaction::defaultCategory('expense'));
+    }
+}


### PR DESCRIPTION
## Summary
- add grouped income and expense category lists to the financial transaction model and expose helper accessors
- update Filament forms and tables to surface the expanded categories with type-specific defaults and searchable filters
- align factories with the new helpers and cover them with unit tests

## Testing
- php artisan test *(fails locally: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e295cde074832cbb691c19b4e4a418