### PR TITLE
Add Filament profit and loss reporting

### DIFF
--- a/app/Filament/Pages/ProfitAndLossReport.php
+++ b/app/Filament/Pages/ProfitAndLossReport.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Services\FinancialReports\ProfitAndLossReportService;
+use BackedEnum;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Filament\Pages\Page;
+use NumberFormatter;
+use UnitEnum;
+
+class ProfitAndLossReport extends Page
+{
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-presentation-chart-line';
+
+    protected static string|UnitEnum|null $navigationGroup = 'Finance';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static ?string $title = 'Profit & Loss';
+
+    protected string $view = 'filament.pages.profit-and-loss-report';
+
+    public string $period = 'this_month';
+
+    public ?string $startDate = null;
+
+    public ?string $endDate = null;
+
+    public string $periodLabel = '';
+
+    /** @var array{income: float, expenses: float, net: float} */
+    public array $summary = [
+        'income' => 0.0,
+        'expenses' => 0.0,
+        'net' => 0.0,
+    ];
+
+    /** @var array{income: array<int, array{category: string, total: float}>, expenses: array<int, array{category: string, total: float}>} */
+    public array $categories = [
+        'income' => [],
+        'expenses' => [],
+    ];
+
+    /** @var array<int, array{month: string, income: float, expenses: float, net: float}> */
+    public array $trend = [];
+
+    public function mount(): void
+    {
+        $this->syncPeriodDates();
+        $this->updateReport();
+    }
+
+    public function updateReport(): void
+    {
+        [$start, $end] = $this->resolvePeriodDates();
+
+        if ($this->period === 'custom' && (! $start || ! $end)) {
+            $this->summary = [
+                'income' => 0.0,
+                'expenses' => 0.0,
+                'net' => 0.0,
+            ];
+            $this->categories = [
+                'income' => [],
+                'expenses' => [],
+            ];
+            $this->trend = [];
+            $this->periodLabel = 'Select a start and end date';
+
+            return;
+        }
+
+        /** @var ProfitAndLossReportService $service */
+        $service = app(ProfitAndLossReportService::class);
+
+        $report = $service->generate($start, $end);
+
+        $this->summary = $report['totals'];
+        $this->categories = [
+            'income' => collect($report['breakdown']['income'] ?? [])->map(function ($total, $category) {
+                return [
+                    'category' => (string) $category,
+                    'total' => (float) $total,
+                ];
+            })->values()->all(),
+            'expenses' => collect($report['breakdown']['expenses'] ?? [])->map(function ($total, $category) {
+                return [
+                    'category' => (string) $category,
+                    'total' => (float) $total,
+                ];
+            })->values()->all(),
+        ];
+
+        $this->trend = $service->monthlyTrend($start, $end);
+        $this->periodLabel = $this->describePeriod($start, $end);
+    }
+
+    public function updatedPeriod(): void
+    {
+        if ($this->period === 'custom') {
+            $this->startDate = null;
+            $this->endDate = null;
+            $this->periodLabel = 'Select a start and end date';
+        } else {
+            $this->syncPeriodDates();
+        }
+
+        $this->updateReport();
+    }
+
+    public function updatedStartDate(): void
+    {
+        if ($this->period === 'custom') {
+            $this->updateReport();
+        }
+    }
+
+    public function updatedEndDate(): void
+    {
+        if ($this->period === 'custom') {
+            $this->updateReport();
+        }
+    }
+
+    /**
+     * @return array{0: ?CarbonInterface, 1: ?CarbonInterface}
+     */
+    protected function resolvePeriodDates(): array
+    {
+        $now = Carbon::now();
+
+        return match ($this->period) {
+            'this_month' => [$now->copy()->startOfMonth(), $now->copy()->endOfMonth()],
+            'last_month' => [
+                $now->copy()->subMonth()->startOfMonth(),
+                $now->copy()->subMonth()->endOfMonth(),
+            ],
+            'this_quarter' => [$now->copy()->startOfQuarter(), $now->copy()->endOfQuarter()],
+            'this_year' => [$now->copy()->startOfYear(), $now->copy()->endOfYear()],
+            'last_year' => [
+                $now->copy()->subYear()->startOfYear(),
+                $now->copy()->subYear()->endOfYear(),
+            ],
+            'year_to_date' => [$now->copy()->startOfYear(), $now->copy()],
+            'custom' => $this->resolveCustomDates(),
+            default => [$now->copy()->startOfMonth(), $now->copy()->endOfMonth()],
+        };
+    }
+
+    /**
+     * @return array{0: ?CarbonInterface, 1: ?CarbonInterface}
+     */
+    protected function resolveCustomDates(): array
+    {
+        $start = $this->startDate ? Carbon::parse($this->startDate)->startOfDay() : null;
+        $end = $this->endDate ? Carbon::parse($this->endDate)->startOfDay() : null;
+
+        if ($start && $end && $start->greaterThan($end)) {
+            [$start, $end] = [$end, $start];
+            $this->startDate = $start->toDateString();
+            $this->endDate = $end->toDateString();
+        }
+
+        return [$start, $end];
+    }
+
+    protected function syncPeriodDates(): void
+    {
+        if ($this->period === 'custom') {
+            return;
+        }
+
+        [$start, $end] = $this->resolvePeriodDates();
+
+        $this->startDate = $start?->toDateString();
+        $this->endDate = $end?->toDateString();
+    }
+
+    protected function describePeriod(?CarbonInterface $start, ?CarbonInterface $end): string
+    {
+        if (! $start && ! $end) {
+            return 'All time';
+        }
+
+        if ($start && $end) {
+            if ($start->isSameDay($end)) {
+                return $start->format('j M Y');
+            }
+
+            return sprintf('%s — %s', $start->format('j M Y'), $end->format('j M Y'));
+        }
+
+        if ($start) {
+            return sprintf('%s onwards', $start->format('j M Y'));
+        }
+
+        return sprintf('Until %s', $end->format('j M Y'));
+    }
+
+    public function periodOptions(): array
+    {
+        return [
+            'this_month' => 'This month',
+            'last_month' => 'Last month',
+            'this_quarter' => 'This quarter',
+            'year_to_date' => 'Year to date',
+            'this_year' => 'This year',
+            'last_year' => 'Last year',
+            'custom' => 'Custom range',
+        ];
+    }
+
+    public function formatCurrency(int|float $value): string
+    {
+        $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
+
+        $formatted = $formatter->formatCurrency($value, 'GBP');
+
+        if ($formatted !== false) {
+            return $formatted;
+        }
+
+        return '£' . number_format($value, 2);
+    }
+
+    public function formatCategory(string $category): string
+    {
+        return ucwords(str_replace('_', ' ', $category));
+    }
+}

--- a/app/Http/Controllers/Api/FinancialReportController.php
+++ b/app/Http/Controllers/Api/FinancialReportController.php
@@ -4,59 +4,24 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ProfitAndLossRequest;
-use App\Models\FinancialTransaction;
+use App\Services\FinancialReports\ProfitAndLossReportService;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Collection;
 
 class FinancialReportController extends Controller
 {
-    public function __invoke(ProfitAndLossRequest $request): JsonResponse
-    {
+    public function __invoke(
+        ProfitAndLossRequest $request,
+        ProfitAndLossReportService $reportService
+    ): JsonResponse {
         $validated = $request->validated();
-        $startDate = $validated['start_date'];
-        $endDate = $validated['end_date'];
 
-        $query = FinancialTransaction::query()
-            ->whereBetween('transaction_date', [$startDate, $endDate]);
-
-        $typeTotals = (clone $query)
-            ->selectRaw('type, SUM(amount) as total')
-            ->groupBy('type')
-            ->pluck('total', 'type');
-
-        $categoryBreakdown = (clone $query)
-            ->selectRaw('type, category, SUM(amount) as total')
-            ->groupBy('type', 'category')
-            ->get()
-            ->groupBy('type')
-            ->map(fn (Collection $rows) => $rows
-                ->sortBy('category')
-                ->mapWithKeys(fn ($row) => [
-                    $row->category => round((float) $row->total, 2),
-                ])
-                ->all()
-            );
-
-        $incomeTotal = round((float) ($typeTotals['income'] ?? 0), 2);
-        $expenseTotal = round((float) ($typeTotals['expense'] ?? 0), 2);
-        $netTotal = round($incomeTotal - $expenseTotal, 2);
+        $report = $reportService->generate(
+            $validated['start_date'],
+            $validated['end_date']
+        );
 
         return response()->json([
-            'data' => [
-                'period' => [
-                    'start_date' => $startDate,
-                    'end_date' => $endDate,
-                ],
-                'totals' => [
-                    'income' => $incomeTotal,
-                    'expenses' => $expenseTotal,
-                    'net' => $netTotal,
-                ],
-                'breakdown' => [
-                    'income' => $categoryBreakdown->get('income', []),
-                    'expenses' => $categoryBreakdown->get('expense', []),
-                ],
-            ],
+            'data' => $report,
         ]);
     }
 }

--- a/app/Services/FinancialReports/ProfitAndLossReportService.php
+++ b/app/Services/FinancialReports/ProfitAndLossReportService.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services\FinancialReports;
+
+use App\Models\FinancialTransaction;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Collection;
+
+class ProfitAndLossReportService
+{
+    /**
+     * Generate a profit and loss report for the provided period.
+     *
+     * @param  CarbonInterface|string  $startDate
+     * @param  CarbonInterface|string  $endDate
+     * @return array{
+     *     period: array{start_date: string, end_date: string},
+     *     totals: array{income: float, expenses: float, net: float},
+     *     breakdown: array{income: array<string, float>, expenses: array<string, float>}
+     * }
+     */
+    public function generate(CarbonInterface|string $startDate, CarbonInterface|string $endDate): array
+    {
+        $start = $this->parseDate($startDate);
+        $end = $this->parseDate($endDate);
+
+        $query = FinancialTransaction::query()
+            ->whereBetween('transaction_date', [$start, $end]);
+
+        $typeTotals = (clone $query)
+            ->selectRaw('type, SUM(amount) as total')
+            ->groupBy('type')
+            ->pluck('total', 'type');
+
+        $categoryBreakdown = (clone $query)
+            ->selectRaw('type, category, SUM(amount) as total')
+            ->groupBy('type', 'category')
+            ->get()
+            ->groupBy('type')
+            ->map(fn (Collection $rows) => $rows
+                ->sortBy('category')
+                ->mapWithKeys(fn ($row) => [
+                    $row->category => round((float) $row->total, 2),
+                ])
+                ->all()
+            );
+
+        $incomeTotal = round((float) ($typeTotals['income'] ?? 0), 2);
+        $expenseTotal = round((float) ($typeTotals['expense'] ?? 0), 2);
+        $netTotal = round($incomeTotal - $expenseTotal, 2);
+
+        return [
+            'period' => [
+                'start_date' => $start->toDateString(),
+                'end_date' => $end->toDateString(),
+            ],
+            'totals' => [
+                'income' => $incomeTotal,
+                'expenses' => $expenseTotal,
+                'net' => $netTotal,
+            ],
+            'breakdown' => [
+                'income' => $categoryBreakdown->get('income', []),
+                'expenses' => $categoryBreakdown->get('expense', []),
+            ],
+        ];
+    }
+
+    /**
+     * Calculate the month-on-month trend for the provided period.
+     *
+     * @return array<int, array{month: string, income: float, expenses: float, net: float}>
+     */
+    public function monthlyTrend(?CarbonInterface $startDate, ?CarbonInterface $endDate): array
+    {
+        $query = FinancialTransaction::query()
+            ->when($startDate, fn ($q) => $q->whereDate('transaction_date', '>=', $startDate))
+            ->when($endDate, fn ($q) => $q->whereDate('transaction_date', '<=', $endDate))
+            ->select(['transaction_date', 'type', 'amount']);
+
+        return $query->get()
+            ->groupBy(fn (FinancialTransaction $transaction) => $transaction->transaction_date->format('Y-m'))
+            ->sortKeys()
+            ->map(function (Collection $transactions) {
+                $income = $transactions->where('type', 'income')->sum('amount');
+                $expenses = $transactions->where('type', 'expense')->sum('amount');
+                $first = $transactions->first();
+
+                $monthLabel = $first?->transaction_date?->copy()->startOfMonth()->format('M Y');
+
+                return [
+                    'month' => $monthLabel ?? 'Unknown',
+                    'income' => round((float) $income, 2),
+                    'expenses' => round((float) $expenses, 2),
+                    'net' => round((float) ($income - $expenses), 2),
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    private function parseDate(CarbonInterface|string $date): CarbonInterface
+    {
+        return $date instanceof CarbonInterface
+            ? $date
+            : Carbon::parse($date)->startOfDay();
+    }
+}

--- a/resources/views/filament/pages/profit-and-loss-report.blade.php
+++ b/resources/views/filament/pages/profit-and-loss-report.blade.php
@@ -1,0 +1,156 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <form wire:submit.prevent="updateReport" class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-sm rounded-xl p-6 space-y-4">
+            <div class="grid gap-4 md:grid-cols-4">
+                <div class="md:col-span-2">
+                    <label for="period" class="block text-sm font-semibold text-gray-700 dark:text-gray-200">Reporting period</label>
+                    <select
+                        wire:model="period"
+                        id="period"
+                        class="mt-1 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500"
+                    >
+                        @foreach ($this->periodOptions() as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div>
+                    <label for="startDate" class="block text-sm font-semibold text-gray-700 dark:text-gray-200">Start date</label>
+                    <input
+                        wire:model="startDate"
+                        type="date"
+                        id="startDate"
+                        @disabled($period !== 'custom')
+                        class="mt-1 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500 disabled:opacity-60"
+                    />
+                </div>
+
+                <div>
+                    <label for="endDate" class="block text-sm font-semibold text-gray-700 dark:text-gray-200">End date</label>
+                    <input
+                        wire:model="endDate"
+                        type="date"
+                        id="endDate"
+                        @disabled($period !== 'custom')
+                        class="mt-1 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500 disabled:opacity-60"
+                    />
+                </div>
+            </div>
+
+            <div class="flex flex-wrap items-center justify-between gap-2">
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                    {{ $periodLabel }}
+                </p>
+
+                <button
+                    type="submit"
+                    class="inline-flex items-center justify-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                >
+                    Refresh report
+                </button>
+            </div>
+        </form>
+
+        <div class="grid gap-4 md:grid-cols-3">
+            <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+                <p class="text-sm font-medium text-gray-600 dark:text-gray-300">Total income</p>
+                <p class="mt-2 text-2xl font-semibold text-emerald-600 dark:text-emerald-400">{{ $this->formatCurrency($summary['income'] ?? 0) }}</p>
+            </div>
+
+            <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+                <p class="text-sm font-medium text-gray-600 dark:text-gray-300">Total expenses</p>
+                <p class="mt-2 text-2xl font-semibold text-rose-600 dark:text-rose-400">{{ $this->formatCurrency($summary['expenses'] ?? 0) }}</p>
+            </div>
+
+            <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+                <p class="text-sm font-medium text-gray-600 dark:text-gray-300">Net result</p>
+                @php
+                    $net = $summary['net'] ?? 0;
+                    $netColour = $net >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400';
+                @endphp
+                <p class="mt-2 text-2xl font-semibold {{ $netColour }}">{{ $this->formatCurrency($net) }}</p>
+            </div>
+        </div>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+                <div class="flex items-center justify-between">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Income breakdown</h3>
+                    <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ $this->formatCurrency($summary['income'] ?? 0) }}</span>
+                </div>
+
+                @if (! empty($categories['income']))
+                    <ul class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach ($categories['income'] as $item)
+                            <li class="flex items-center justify-between py-2 text-sm">
+                                <span class="text-gray-700 dark:text-gray-200">{{ $this->formatCategory($item['category']) }}</span>
+                                <span class="font-medium text-gray-900 dark:text-gray-100">{{ $this->formatCurrency($item['total']) }}</span>
+                            </li>
+                        @endforeach
+                    </ul>
+                @else
+                    <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">No income recorded for this period.</p>
+                @endif
+            </div>
+
+            <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+                <div class="flex items-center justify-between">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Expense breakdown</h3>
+                    <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ $this->formatCurrency($summary['expenses'] ?? 0) }}</span>
+                </div>
+
+                @if (! empty($categories['expenses']))
+                    <ul class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach ($categories['expenses'] as $item)
+                            <li class="flex items-center justify-between py-2 text-sm">
+                                <span class="text-gray-700 dark:text-gray-200">{{ $this->formatCategory($item['category']) }}</span>
+                                <span class="font-medium text-gray-900 dark:text-gray-100">{{ $this->formatCurrency($item['total']) }}</span>
+                            </li>
+                        @endforeach
+                    </ul>
+                @else
+                    <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">No expenses recorded for this period.</p>
+                @endif
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+            <div class="flex items-center justify-between">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Monthly performance</h3>
+                <span class="text-sm text-gray-600 dark:text-gray-300">Net movement across the selected window</span>
+            </div>
+
+            @if (! empty($trend))
+                <div class="mt-4 overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                        <thead class="bg-gray-50 dark:bg-gray-800/60">
+                            <tr>
+                                <th scope="col" class="px-4 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Month</th>
+                                <th scope="col" class="px-4 py-2 text-right font-semibold text-gray-700 dark:text-gray-200">Income</th>
+                                <th scope="col" class="px-4 py-2 text-right font-semibold text-gray-700 dark:text-gray-200">Expenses</th>
+                                <th scope="col" class="px-4 py-2 text-right font-semibold text-gray-700 dark:text-gray-200">Net</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($trend as $row)
+                                @php
+                                    $netValue = $row['net'];
+                                    $trendColour = $netValue >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400';
+                                @endphp
+                                <tr>
+                                    <td class="px-4 py-2 text-gray-700 dark:text-gray-200">{{ $row['month'] }}</td>
+                                    <td class="px-4 py-2 text-right text-gray-900 dark:text-gray-100">{{ $this->formatCurrency($row['income']) }}</td>
+                                    <td class="px-4 py-2 text-right text-gray-900 dark:text-gray-100">{{ $this->formatCurrency($row['expenses']) }}</td>
+                                    <td class="px-4 py-2 text-right font-semibold {{ $trendColour }}">{{ $this->formatCurrency($netValue) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @else
+                <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">No transactions available to build a trend for this period.</p>
+            @endif
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/tests/Unit/Services/ProfitAndLossReportServiceTest.php
+++ b/tests/Unit/Services/ProfitAndLossReportServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\FinancialTransaction;
+use App\Services\FinancialReports\ProfitAndLossReportService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProfitAndLossReportServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_generate_returns_totals_and_breakdown_for_period(): void
+    {
+        FinancialTransaction::factory()->income()->create([
+            'category' => 'rental_income',
+            'amount' => 1200,
+            'transaction_date' => '2024-02-10',
+        ]);
+
+        FinancialTransaction::factory()->income()->create([
+            'category' => 'deposit',
+            'amount' => 300,
+            'transaction_date' => '2024-02-18',
+        ]);
+
+        FinancialTransaction::factory()->expense()->create([
+            'category' => 'maintenance',
+            'amount' => 250,
+            'transaction_date' => '2024-02-20',
+        ]);
+
+        FinancialTransaction::factory()->expense()->create([
+            'category' => 'fuel',
+            'amount' => 75,
+            'transaction_date' => '2024-03-01',
+        ]);
+
+        // Outside of the reporting period and should be ignored.
+        FinancialTransaction::factory()->income()->create([
+            'category' => 'rental_income',
+            'amount' => 999,
+            'transaction_date' => '2023-12-31',
+        ]);
+
+        $service = new ProfitAndLossReportService();
+
+        $report = $service->generate('2024-02-01', '2024-03-31');
+
+        $this->assertSame([
+            'start_date' => '2024-02-01',
+            'end_date' => '2024-03-31',
+        ], $report['period']);
+
+        $this->assertEquals(1500.0, $report['totals']['income']);
+        $this->assertEquals(325.0, $report['totals']['expenses']);
+        $this->assertEquals(1175.0, $report['totals']['net']);
+
+        $this->assertSame([
+            'deposit' => 300.0,
+            'rental_income' => 1200.0,
+        ], $report['breakdown']['income']);
+
+        $this->assertSame([
+            'fuel' => 75.0,
+            'maintenance' => 250.0,
+        ], $report['breakdown']['expenses']);
+    }
+
+    public function test_monthly_trend_rolls_up_income_and_expenses(): void
+    {
+        FinancialTransaction::factory()->income()->create([
+            'amount' => 800,
+            'transaction_date' => '2024-01-05',
+        ]);
+
+        FinancialTransaction::factory()->expense()->create([
+            'amount' => 150,
+            'transaction_date' => '2024-01-18',
+        ]);
+
+        FinancialTransaction::factory()->income()->create([
+            'amount' => 600,
+            'transaction_date' => '2024-02-02',
+        ]);
+
+        FinancialTransaction::factory()->expense()->create([
+            'amount' => 200,
+            'transaction_date' => '2024-02-15',
+        ]);
+
+        FinancialTransaction::factory()->income()->create([
+            'amount' => 400,
+            'transaction_date' => '2024-03-10',
+        ]);
+
+        $service = new ProfitAndLossReportService();
+
+        $trend = $service->monthlyTrend(
+            Carbon::parse('2024-01-01'),
+            Carbon::parse('2024-03-31')
+        );
+
+        $this->assertSame([
+            [
+                'month' => 'Jan 2024',
+                'income' => 800.0,
+                'expenses' => 150.0,
+                'net' => 650.0,
+            ],
+            [
+                'month' => 'Feb 2024',
+                'income' => 600.0,
+                'expenses' => 200.0,
+                'net' => 400.0,
+            ],
+            [
+                'month' => 'Mar 2024',
+                'income' => 400.0,
+                'expenses' => 0.0,
+                'net' => 400.0,
+            ],
+        ], $trend);
+    }
+}


### PR DESCRIPTION
## Summary
- extract the profit and loss aggregation logic into a reusable service that can power multiple surfaces
- add a Filament "Profit & Loss" admin page with period controls, breakdowns, and a monthly trend
- cover the report service with focused unit tests and reuse it from the existing API controller

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68e2950493d0832c84e453b5f0c541a8