### PR TITLE
Fix Filament navigation group type declaration

### DIFF
--- a/app/Filament/Resources/CustomerResource.php
+++ b/app/Filament/Resources/CustomerResource.php
@@ -9,12 +9,13 @@ use Filament\Resources\Form;
 use Filament\Resources\Resource;
 use Filament\Resources\Table;
 use Filament\Tables;
+use UnitEnum;
 
 class CustomerResource extends Resource
 {
     protected static ?string $model = Customer::class;
 
-    protected static ?string $navigationGroup = 'Finance';
+    protected static UnitEnum|string|null $navigationGroup = 'Finance';
 
     protected static ?string $navigationIcon = 'heroicon-o-user-group';
 


### PR DESCRIPTION
## Summary
- align CustomerResource navigation group property with Filament 4 type requirements
- import UnitEnum to support the broadened property type declaration

## Testing
- php artisan migrate --pretend *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e40b0e792c832cb6c5dea34be90b50